### PR TITLE
Group and personal funds

### DIFF
--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -1,10 +1,12 @@
 module.exports = 
   url: '/groups/:groupId'
   template: require('./group-page.html')
-  controller: ($scope, Records, $stateParams, $location) ->
+  controller: ($scope, Records, $stateParams, $location, CurrentUser) ->
     groupId = parseInt($stateParams.groupId) 
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
+      $scope.currentMembership = group.membershipFor(CurrentUser.get())
+      console.log('(group-page) currentMembership: ', $scope.currentMembership)
       Records.buckets.fetchByGroupId(group.id)
       Records.memberships.fetchByGroupId(group.id)
 

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -23,8 +23,7 @@
         </div>
         <div layout="column" layout-align="center center">
           <span class="group-page__funds-overview-header">Your funds</span>
-          <!-- <span class="group-page__funds-overview-amount">{{ group.personalFunds | currency : "$" : 0 }}</span> -->
-          <span class="group-page__funds-overview-amount">$250</span>
+          <span class="group-page__funds-overview-amount">{{ currentMembership.balance() | currency : "$" : 0 }}</span>
         </div>
       </div>
       <div flex="50" layout="row" class="group-page__funds-overview" >
@@ -33,8 +32,7 @@
         </div>
         <div layout="column" layout-align="center center">
           <span class="group-page__funds-overview-header">Total funds</span>
-          <!-- <span class="group-page__funds-overview-amount">{{ group.totalFunds | currency : "$" : 0  }}</span> -->
-          <span class="group-page__funds-overview-amount">$10000</span>
+          <span class="group-page__funds-overview-amount">{{ group.balance | currency : "$" : 0  }}</span>
         </div>
       </div>
     </div>

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -6,10 +6,10 @@ module.exports =
     groupId = parseInt $stateParams.groupId
     projectId = parseInt $stateParams.projectId
 
-
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
       $scope.currentMembership = group.membershipFor(CurrentUser.get())
+      console.log('(project-page) currentMembership: ', $scope.currentMembership)
 
     Records.buckets.findOrFetchById(projectId).then (project) ->
       $scope.project = project

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -1,13 +1,15 @@
 module.exports = 
   url: '/groups/:groupId/projects/:projectId'
   template: require('./project-page.html')
-  controller: ($scope, Records, $stateParams, $location) ->
+  controller: ($scope, Records, $stateParams, $location, CurrentUser) ->
 
     groupId = parseInt $stateParams.groupId
     projectId = parseInt $stateParams.projectId
 
+
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
+      $scope.currentMembership = group.membershipFor(CurrentUser.get())
 
     Records.buckets.findOrFetchById(projectId).then (project) ->
       $scope.project = project

--- a/app/components/project-page/project-page.html
+++ b/app/components/project-page/project-page.html
@@ -13,8 +13,7 @@
         </div>
         <div layout="column" layout-align="center center">
           <span class="project-page__funds-overview-header">Your funds</span>
-          <!-- <span class="project-page__funds-overview-amount">{{ group.personalFunds | currency : "$" : 0 }}</span> -->
-          <span class="project-page__funds-overview-amount">$250</span>
+          <span class="project-page__funds-overview-amount">{{ currentMembership.balance() | currency : "$" : 0 }}</span>
         </div>
       </span>
 

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -1,7 +1,7 @@
 module.exports = 
   url: '/'
   template: require('./welcome-page.html')
-  controller: ($scope, $auth, $location, Records) ->
+  controller: ($scope, $auth, $location, Records, CurrentUser) ->
     $scope.login = (formData) ->
       $scope.formError = ""
       $auth.submitLogin({
@@ -10,7 +10,10 @@ module.exports =
       }).then ->
         Records.memberships.fetchMyMemberships()
 
-    $scope.$on 'auth:login-success', () ->
+    $scope.$on 'auth:login-success', (event, user) ->
+      Records.users.fetchMe()
+      CurrentUser.setId(user.id)
+      # TODO: make this go to the first group of the user's groups
       $location.path('/groups/1')
 
     $scope.$on 'auth:login-error', () ->

--- a/app/index.js
+++ b/app/index.js
@@ -22,7 +22,8 @@ global.cobudgetApp = angular.module('cobudget', [
   'ui.router',
   'ng-token-auth',
   'ngMaterial',
-  'ngMessages'
+  'ngMessages',
+  'ipCookie'
 ])
 .constant('config', require('app/configs/app'))
 
@@ -36,3 +37,4 @@ concatenify('./controllers/*.{js,coffee}')
 concatenify('./records-interfaces/*.{js,coffee}')
 concatenify('./models/*.{js,coffee}')
 concatenify('./filters/*.{js,coffee}')
+concatenify('./services/*.{js,coffee}')

--- a/app/models/bucket-model.coffee
+++ b/app/models/bucket-model.coffee
@@ -17,3 +17,9 @@ global.cobudgetApp.factory 'BucketModel', (BaseModel) ->
 
     percentFunded: ->
       @totalContributions / @target * 100
+
+    # openForFunding: ->
+    #   @remote.postMember(@,'open_for_funding',{target: @target, })
+      # Moment.format *****
+      # @remote is an instance of the restful client        
+      

--- a/app/models/group-model.coffee
+++ b/app/models/group-model.coffee
@@ -22,7 +22,11 @@ global.cobudgetApp.factory 'GroupModel', (BaseModel) ->
     members: ->
       _.map @memberships(), (membership) ->
         membership.member()
-                      
+
+    membershipFor: (member) ->
+      _.first _.filter @memberships(), (membership) ->
+        membership.memberId == member.id
+
     # personalFunds: ->
 
     # totalFunds: ->

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -1,3 +1,6 @@
+null
+
+### @ngInject ###
 global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
   class MembershipModel extends BaseModel
     @singular: 'membership'

--- a/app/records-interfaces/user-records-interface.coffee
+++ b/app/records-interfaces/user-records-interface.coffee
@@ -4,3 +4,6 @@ global.cobudgetApp.factory 'UserRecordsInterface', (config, BaseRecordsInterface
     constructor: (recordStore) ->
       @baseConstructor recordStore
       @remote.apiPrefix = config.apiPrefix
+    fetchMe: ->
+      @fetch
+        path: 'me'

--- a/app/services/current-user.coffee
+++ b/app/services/current-user.coffee
@@ -1,0 +1,11 @@
+null
+
+### @ngInject ###
+global.cobudgetApp.factory 'CurrentUser', (Records, AppConfig, ipCookie) ->
+
+  setId: (id) ->
+    ipCookie('currentUserId', id)
+
+  get: ->
+    id = ipCookie('currentUserId')
+    Records.users.find(id)

--- a/app/services/current-user.coffee
+++ b/app/services/current-user.coffee
@@ -1,7 +1,7 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'CurrentUser', (Records, AppConfig, ipCookie) ->
+global.cobudgetApp.factory 'CurrentUser', (Records, ipCookie) ->
 
   setId: (id) ->
     ipCookie('currentUserId', id)


### PR DESCRIPTION
skyped with @robguthrie today, who helped me set up and use a new CurrentUser service. 

the UI now has the concept of a 'current user', whose id is stored in a cookie. 

now that we have the concept of a current user, we can display the current user's 'personal funds' on the project and group pages.

the group's funds are also displayed on the group page. 

there is a little bug, where the current user's personal funds returns `undefined` on page reload. but, i am going to merge this pull request for now so that i continue working on other tickets.

tomorrow, whenever @robguthrie is available, we'll sort that bug out and everything should be all good.