### PR TITLE
setup beta deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ npm start
 
 ### Deploy
 
-*Stage (push to gh-pages)*
+*Stage (push to this repo's gh-pages)*
 
 ```
 NODE_ENV=production npm run stage
 ```
 
-*Deploy (push to heroku)*
+*Deploy (push to prod repo's gh-pages)*
 
 ```
 npm run set-remote

--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ npm start
 NODE_ENV=production npm run stage
 ```
 
-*Deploy (push to dokku)*
+*Deploy (push to heroku)*
 
 ```
-git remote add deploy dokku@next.cobudget.co:app
+npm run set-remote
+npm run set-buildpack
 ```
 
 ```
-NODE_ENV=production npm run deploy
+npm run deploy
 ```
 
 ### Test

--- a/app/assets/CNAME
+++ b/app/assets/CNAME
@@ -1,1 +1,1 @@
-staging.cobudget.co
+beta.cobudget.co

--- a/config/production.js
+++ b/config/production.js
@@ -1,3 +1,3 @@
 module.exports = {
-  apiEndpoint: "https://cobudget-api.herokuapp.com"
+  apiPrefix: "https://cobudget-beta-api.herokuapp.com/api/v1"
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "angular-sanitize": "^1.3.8",
     "angular-ui-router": "^0.2.11",
     "angular_record_store": "git://github.com/loomio/angular_record_store.git#2.0.5",
-    "babelify": "^5.0.3",
-    "coffeeify": "^1.1.0",
     "debug": "^2.1.0",
     "es5-shim": "^4.0.3",
     "font-awesome": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "build": "gulp build",
     "develop": "gulp develop",
     "stage": "(export NODE_ENV=staging; gulp branch && git push origin gh-pages -f)",
-    "deploy": "(export NODE_ENV=production; gulp branch && git push deploy gh-pages:master -f)"
+    "set-remote": "git remote add deploy-beta git@github.com:cobudget/beta.cobudget.co",
+    "deploy-cname": "echo 'beta.cobudget.co' > app/assets/CNAME",
+    "deploy-push": "git push deploy-beta gh-pages -f",
+    "deploy": "(export NODE_ENV=production; npm run deploy-cname && gulp branch && npm run deploy-push)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
i reckon the best strategy for `cobudget-ui` deploys is as `gh-pages` of a [dedicated GitHub repo](https://github.com/cobudget/beta.cobudget.co), this is easy as the permissions are already setup across the team, there's no additional configuration as GitHub pages automatically deploy upon push, plus GitHub pages are hella performant. :)

the alternatives were Dokku as before or Heroku, both involve a custom buildpack for static site deploys.