### PR TITLE
Flossing

### DIFF
--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -6,17 +6,14 @@ global.cobudgetApp.run ($rootScope, Records, $q, $location) ->
   membershipsLoadedDeferred = $q.defer() # creates a new deferred object with a promise attr
   global.cobudgetApp.membershipsLoaded = membershipsLoadedDeferred.promise # copy reference to the promise, so its globally accessible to the controller resolve
 
-  checkIfUserSignedIn = $q.defer()
-  global.cobudgetApp.checkIfUserSignedIn = checkIfUserSignedIn.promise
-  
-  $rootScope.$on 'auth:validation-success', (event, user) ->
-    console.log('user signed in')
-    checkIfUserSignedIn.resolve(true)
+  authSuccess = (event, user) ->
     global.cobudgetApp.currentUserId = user.id
     Records.memberships.fetchMyMemberships().then ->
       membershipsLoadedDeferred.resolve(true) # when me have all of the memberships, resolve the promise -- the controller loads
-  
-  $rootScope.$on 'auth:validation-error', (event, user) ->
-    console.log('user not signed in')
-    checkIfUserSignedIn.resolve(true)
-    $location.path('/')
+
+  $rootScope.$on 'auth:validation-success', (event, user) ->
+    authSuccess(event, user)
+
+  $rootScope.$on 'auth:login-success', (event, user) ->
+    authSuccess(event, user).then ->
+      $location.path('/groups/1')

--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -16,4 +16,6 @@ global.cobudgetApp.run ($rootScope, Records, $q, $location) ->
 
   $rootScope.$on 'auth:login-success', (event, user) ->
     authSuccess(event, user).then ->
-      $location.path('/groups/1')
+      # TODO: later, this will be the first group that the user is a member of
+      global.cobudgetApp.currentGroupId = 1
+      $location.path("/groups/#{global.cobudgetApp.currentGroupId}")

--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -1,10 +1,22 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.run ($rootScope, Records, $q) ->
-  deferred = $q.defer() # creates a new deferred object with a promise attr
-  global.cobudgetApp.membershipsLoaded = deferred.promise # copy reference to the promise, so its globally accessible to the controller resolve
+global.cobudgetApp.run ($rootScope, Records, $q, $location) ->
+
+  membershipsLoadedDeferred = $q.defer() # creates a new deferred object with a promise attr
+  global.cobudgetApp.membershipsLoaded = membershipsLoadedDeferred.promise # copy reference to the promise, so its globally accessible to the controller resolve
+
+  checkIfUserSignedIn = $q.defer()
+  global.cobudgetApp.checkIfUserSignedIn = checkIfUserSignedIn.promise
+  
   $rootScope.$on 'auth:validation-success', (event, user) ->
+    console.log('user signed in')
+    checkIfUserSignedIn.resolve(true)
     global.cobudgetApp.currentUserId = user.id
     Records.memberships.fetchMyMemberships().then ->
-      deferred.resolve(true) # when me have all of the memberships, resolve the promise -- the controller loads
+      membershipsLoadedDeferred.resolve(true) # when me have all of the memberships, resolve the promise -- the controller loads
+  
+  $rootScope.$on 'auth:validation-error', (event, user) ->
+    console.log('user not signed in')
+    checkIfUserSignedIn.resolve(true)
+    $location.path('/')

--- a/app/components/create-project-page/create-project-page.coffee
+++ b/app/components/create-project-page/create-project-page.coffee
@@ -10,6 +10,7 @@ module.exports =
 
     $scope.done = () ->
       if $scope.bucketForm.$valid
-        # temp hack - because, save doesn't set the right request headers
-        $scope.bucket.create().then ->
-          $scope.cancel()
+        $scope.bucket.save().then (data) ->
+          bucketId = data.buckets[0].id
+          $location.path("/groups/#{$scope.bucket.groupId}/projects/#{bucketId}")
+          Toast.show('You launched a project for funding')

--- a/app/components/create-project-page/create-project-page.coffee
+++ b/app/components/create-project-page/create-project-page.coffee
@@ -16,4 +16,4 @@ module.exports =
         $scope.bucket.save().then (data) ->
           projectId = data.buckets[0].id
           $location.path("/projects/#{projectId}")
-          Toast.show('You launched a project for funding')
+          Toast.show('You drafted a new project')

--- a/app/components/create-project-page/create-project-page.coffee
+++ b/app/components/create-project-page/create-project-page.coffee
@@ -1,10 +1,7 @@
 module.exports = 
-  resolve: 
-    checkIfUserSignedIn: ->
-      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId/projects/new'
   template: require('./create-project-page.html')
-  controller: ($scope, Records, $stateParams, $location) ->
+  controller: ($scope, Records, $stateParams, $location, Toast) ->
     $scope.bucket = Records.buckets.build()
     $scope.bucket.groupId = parseInt($stateParams.groupId)
       

--- a/app/components/create-project-page/create-project-page.coffee
+++ b/app/components/create-project-page/create-project-page.coffee
@@ -1,4 +1,7 @@
 module.exports = 
+  resolve: 
+    checkIfUserSignedIn: ->
+      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId/projects/new'
   template: require('./create-project-page.html')
   controller: ($scope, Records, $stateParams, $location) ->

--- a/app/components/create-project-page/create-project-page.coffee
+++ b/app/components/create-project-page/create-project-page.coffee
@@ -1,16 +1,19 @@
 module.exports = 
-  url: '/groups/:groupId/projects/new'
+  url: '/projects/new'
   template: require('./create-project-page.html')
-  controller: ($scope, Records, $stateParams, $location, Toast) ->
+  controller: ($scope, Records, $location, Toast) ->
+
+    groupId = global.cobudgetApp.currentGroupId
+
     $scope.bucket = Records.buckets.build()
-    $scope.bucket.groupId = parseInt($stateParams.groupId)
+    $scope.bucket.groupId = groupId
       
     $scope.cancel = () ->
-      $location.path("/groups/#{$stateParams.groupId}")
+      $location.path("/groups/#{groupId}")
 
     $scope.done = () ->
       if $scope.bucketForm.$valid
         $scope.bucket.save().then (data) ->
-          bucketId = data.buckets[0].id
-          $location.path("/groups/#{$scope.bucket.groupId}/projects/#{bucketId}")
+          projectId = data.buckets[0].id
+          $location.path("/projects/#{projectId}")
           Toast.show('You launched a project for funding')

--- a/app/components/create-project-page/create-project-page.html
+++ b/app/components/create-project-page/create-project-page.html
@@ -18,12 +18,11 @@
   </md-toolbar>
 
   <md-content>
-
     <md-subheader class="create-project-page__subheader-title">You're about to make a project draft</md-subheader>
+
     <md-subheader class="create-project-page__subheader-text">Create a project draft to propose an idea to your peers and get feedback. Once your project gets endorsed, you can request funding.</md-subheader>
 
-    <form name='bucketForm' class="create-project-page__form" ng-keyUp="$event.keyCode == 13 ? done() : null">
-
+    <form name='bucketForm' class="create-project-page__form">
       <md-input-container>
         <label>Title</label>
         <input required name="name" type="text" ng-model="bucket.name">
@@ -44,9 +43,6 @@
         <label>Estimated Funding Target (optional)</label>
         <input name="target" type="number" ng-model="bucket.target">
       </md-input-container>
-
     </form>
-
   </md-content>
-
 </div>

--- a/app/components/edit-project-page/edit-project-page.coffee
+++ b/app/components/edit-project-page/edit-project-page.coffee
@@ -1,19 +1,19 @@
 module.exports = 
-  url: '/groups/:groupId/projects/:projectId/edit'
+  url: '/projects/:projectId/edit'
   template: require('./edit-project-page.html')
-  controller: ($scope, Records, $stateParams, $location) ->
-    $scope.groupId = parseInt $stateParams.groupId
-    $scope.projectId = parseInt $stateParams.projectId
+  controller: ($scope, Records, $stateParams, $location, Toast) ->
+    projectId = parseInt $stateParams.projectId
 
-    Records.buckets.findOrFetchById($scope.projectId).then (bucket) ->
+    Records.buckets.findOrFetchById(projectId).then (bucket) ->
       $scope.bucket = bucket
       # temp hack to get around target form number validation
       $scope.bucket.target = parseInt $scope.bucket.target
             
     $scope.cancel = () ->
-      $location.path("/groups/#{$scope.groupId}/projects/#{$scope.projectId}")
+      $location.path("/projects/#{projectId}")
 
     $scope.done = () ->
       if $scope.bucketForm.$valid
         $scope.bucket.save()
+        Toast.show('Your edits have been saved')
         $scope.cancel()

--- a/app/components/edit-project-page/edit-project-page.html
+++ b/app/components/edit-project-page/edit-project-page.html
@@ -1,5 +1,4 @@
 <div class="edit-project-page">
-
   <md-toolbar class="md-whiteframe-z1 edit-project-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">
       <md-button class="md-icon-button" ng-click="cancel()" aria-label="cancel">
@@ -18,12 +17,11 @@
   </md-toolbar>
 
   <md-content>
-
     <md-subheader class="edit-project-page__subheader-title">You're about to edit a project draft</md-subheader>
+
     <md-subheader class="edit-project-page__subheader-text">You can continue to edit this draft, propose it to your peers, and get feedback. Once your project gets endorsed, you can request funding.</md-subheader>
 
-    <form name='bucketForm' class="edit-project-page__form" ng-keyUp="$event.keyCode == 13 ? done() : null">
-
+    <form name='bucketForm' class="edit-project-page__form">
       <md-input-container>
         <label>Title</label>
         <input required name="name" type="text" ng-model="bucket.name">
@@ -44,9 +42,6 @@
         <label>Estimated Funding Target (optional)</label>
         <input name="target" type="number" ng-model="bucket.target">
       </md-input-container>
-
     </form>
-
   </md-content>
-
 </div>

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -18,10 +18,10 @@ module.exports =
     window.scrollHeight = 0;
 
     $scope.createProject = ->
-      $location.path("/groups/#{$stateParams.groupId}/projects/new")
+      $location.path("/projects/new")
 
     $scope.showProject = (projectId) ->
-      $location.path("/groups/#{$stateParams.groupId}/projects/#{projectId}")
+      $location.path("/projects/#{projectId}")
 
     $scope.selectTab = (tabNum) ->
       $scope.tabSelected = parseInt tabNum

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -2,11 +2,9 @@ module.exports =
   resolve: 
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
-    checkIfUserSignedIn: ->
-      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId'
   template: require('./group-page.html')
-  controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->
+  controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie, Toast) ->
 
     groupId = parseInt($stateParams.groupId) 
     Records.groups.findOrFetchById(groupId).then (group) ->

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -4,7 +4,7 @@ module.exports =
       global.cobudgetApp.membershipsLoaded
   url: '/groups/:groupId'
   template: require('./group-page.html')
-  controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie, Toast) ->
+  controller: ($scope, Records, $stateParams, $location, CurrentUser, Toast) ->
 
     groupId = parseInt($stateParams.groupId) 
     Records.groups.findOrFetchById(groupId).then (group) ->
@@ -23,18 +23,5 @@ module.exports =
 
     $scope.selectTab = (tabNum) ->
       $scope.tabSelected = parseInt tabNum
-
-    $scope.toggleToastStyling = () ->
-      jQuery('.group-page__create-project-fab').toggleClass('group-page__create-project-fab-toasty')
-      jQuery('.group-page__content').toggleClass('group-page__content-toasty')
-
-    if $scope.newProjectOpenForFundingId = ipCookie('newProjectOpenForFundingId')
-      $scope.showToast = true
-      $scope.toggleToastStyling()
-      
-    $scope.showNewLiveProject = (projectId) ->
-      ipCookie('newProjectOpenForFundingId', null)
-      $scope.toggleToastStyling()
-      $scope.showProject(projectId)
 
     return

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -2,6 +2,8 @@ module.exports =
   resolve: 
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
+    checkIfUserSignedIn: ->
+      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId'
   template: require('./group-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -6,7 +6,9 @@ module.exports =
   template: require('./group-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, Toast) ->
 
-    groupId = parseInt($stateParams.groupId) 
+    groupId = parseInt($stateParams.groupId)
+    global.cobudgetApp.currentGroupId = groupId
+    
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
       $scope.currentMembership = group.membershipFor(CurrentUser())

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -124,14 +124,5 @@
       </div>
     </md-button>
   </md-content>
-
-  <div layout="row" layout-align="center center" class="group-page__toast" ng-show="showToast">
-    <div class="group-page__toast-text" flex>
-      You launched a project for funding
-    </div>
-    <div>
-      <md-button class="group-page__toast-button" ng-click="showNewLiveProject(newProjectOpenForFundingId)">View</md-button>
-    </div>      
-  </div>
 </div>
 

--- a/app/components/group-page/group-page.scss
+++ b/app/components/group-page/group-page.scss
@@ -1,3 +1,4 @@
+
 // toolbar heading
 
 .group-page__toolbar {
@@ -62,11 +63,6 @@
   top: calc(#{$medium-height} * 2 + #{$large-height});
 }
 
-.group-page__content-toasty {
-  padding-bottom: $large-height;
-}
-
-
 .group-page__subheader-title {
   color: $cobudget-blue;
 }
@@ -129,31 +125,6 @@
   position: fixed;
   right: 10px;
   bottom: 15px;
-}
-
-.group-page__create-project-fab-toasty {
-  bottom: calc(#{$large-height} + 15px);
-}
-
-.group-page__toast {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  height: $large-height;
-  background: rgba(0,0,0,0.8);
-}
-
-.group-page__toast-text {
-  @include fontSmall;
-  color: white;
-  padding-left: 20px;  
-}
-
-.group-page__toast-button {
-  margin: 0;
-  padding: 0;
-  width: 60px;
-  color: $cobudget-jade;
 }
 
 // funders

--- a/app/components/ng-material-customs.scss
+++ b/app/components/ng-material-customs.scss
@@ -1,0 +1,11 @@
+md-toast {
+  position: fixed;
+}
+
+md-toast > span.ng-binding {
+  @include fontTiny;
+}
+
+md-toast > button.md-button {
+  color: $cobudget-jade;
+}

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -2,6 +2,8 @@ module.exports =
   resolve: 
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
+    checkIfUserSignedIn: ->
+      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId/projects/:projectId'
   template: require('./project-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -2,11 +2,11 @@ module.exports =
   resolve: 
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
-  url: '/groups/:groupId/projects/:projectId'
+  url: '/projects/:projectId'
   template: require('./project-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->
     
-    groupId = parseInt $stateParams.groupId
+    groupId = global.cobudgetApp.currentGroupId
     projectId = parseInt $stateParams.projectId
 
     Records.groups.findOrFetchById(groupId).then (group) ->
@@ -52,7 +52,7 @@ module.exports =
       $scope.back()
 
     $scope.editDraft = ->
-      $location.path("/groups/#{groupId}/projects/#{projectId}/edit")
+      $location.path("/projects/#{projectId}/edit")
 
     $scope.userCanEditDraft = ->
       $scope.project && $scope.project.status == 'draft' && $scope.userCanStartFunding()

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -2,8 +2,6 @@ module.exports =
   resolve: 
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
-    checkIfUserSignedIn: ->
-      global.cobudgetApp.checkIfUserSignedIn
   url: '/groups/:groupId/projects/:projectId'
   template: require('./project-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->

--- a/app/components/project-page/project-page.coffee
+++ b/app/components/project-page/project-page.coffee
@@ -4,7 +4,7 @@ module.exports =
       global.cobudgetApp.membershipsLoaded
   url: '/projects/:projectId'
   template: require('./project-page.html')
-  controller: ($scope, Records, $stateParams, $location, CurrentUser, ipCookie) ->
+  controller: ($scope, Records, $stateParams, $location, CurrentUser, Toast) ->
     
     groupId = global.cobudgetApp.currentGroupId
     projectId = parseInt $stateParams.projectId
@@ -48,7 +48,7 @@ module.exports =
 
     $scope.openForFunding = ->
       $scope.project.openForFunding()
-      ipCookie('newProjectOpenForFundingId', $stateParams.projectId)
+      Toast.showAndRedirect('You launched a project for funding', "/projects/#{projectId}")
       $scope.back()
 
     $scope.editDraft = ->

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -4,11 +4,7 @@ module.exports =
   controller: ($scope, $auth, $location, Records, $rootScope) ->
 
     $rootScope.$on 'auth:validation-success', (event, user) ->
-      $scope.userNotLoggedIn = false
       $location.path('groups/1')
-
-    $rootScope.$on 'auth:validation-error', () ->
-      $scope.userNotLoggedIn = true
 
     $scope.login = (formData) ->
       $scope.formError = ""

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -2,7 +2,7 @@ module.exports =
   url: '/'
   template: require('./welcome-page.html')
   controller: ($scope, $auth, $location, Records, $rootScope) ->
-
+    
     $scope.login = (formData) ->
       $scope.formError = ""
       $auth.submitLogin

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -3,16 +3,11 @@ module.exports =
   template: require('./welcome-page.html')
   controller: ($scope, $auth, $location, Records, $rootScope) ->
 
-    $rootScope.$on 'auth:validation-success', (event, user) ->
-      $location.path('groups/1')
-
     $scope.login = (formData) ->
       $scope.formError = ""
-      $auth.submitLogin(
+      $auth.submitLogin
         email: formData.email
         password: formData.password
-      ).then (user) ->
-        $location.path('/groups/1')
 
     # TODO: how to put inside .fail callback above?
     $scope.$on 'auth:login-error', () ->

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -1,13 +1,21 @@
 module.exports = 
   url: '/'
   template: require('./welcome-page.html')
-  controller: ($scope, $auth, $location, Records) ->
+  controller: ($scope, $auth, $location, Records, $rootScope) ->
+
+    $rootScope.$on 'auth:validation-success', (event, user) ->
+      $scope.userNotLoggedIn = false
+      $location.path('groups/1')
+
+    $rootScope.$on 'auth:validation-error', () ->
+      $scope.userNotLoggedIn = true
+
     $scope.login = (formData) ->
       $scope.formError = ""
-      $auth.submitLogin({
-        email: formData.email, 
+      $auth.submitLogin(
+        email: formData.email
         password: formData.password
-      }).then (user) ->
+      ).then (user) ->
         $location.path('/groups/1')
 
     # TODO: how to put inside .fail callback above?

--- a/app/components/welcome-page/welcome-page.html
+++ b/app/components/welcome-page/welcome-page.html
@@ -1,4 +1,4 @@
-<div class="welcome-page" ng-show="userNotLoggedIn">
+<div class="welcome-page">
   <md-toolbar class="md-primary welcome-page__toolbar">
     <h1 class="md-toolbar-tools welcome-page__heading" layout-align="center">Welcome to Cobudget!</h1>
   </md-toolbar>
@@ -16,7 +16,7 @@
         <label>password</label>
         <input name="password" type="password" ng-model="formData.password">
       </md-input-container>
-
+  
       <input type="submit" value="log in">
     </form>
   </md-content>

--- a/app/components/welcome-page/welcome-page.html
+++ b/app/components/welcome-page/welcome-page.html
@@ -1,5 +1,4 @@
-<div class="welcome-page">
-
+<div class="welcome-page" ng-show="userNotLoggedIn">
   <md-toolbar class="md-primary welcome-page__toolbar">
     <h1 class="md-toolbar-tools welcome-page__heading" layout-align="center">Welcome to Cobudget!</h1>
   </md-toolbar>
@@ -7,16 +6,18 @@
   <md-content layout-padding>
     <form novalidate ng-submit="login(formData)">
       <div class="welcome-page__form-errors">{{ formError }}</div>
+
       <md-input-container>
         <label>email</label>
         <input name="email" type="email" ng-model="formData.email">
       </md-input-container>
+
       <md-input-container>
         <label>password</label>
         <input name="password" type="password" ng-model="formData.password">
       </md-input-container>
+
       <input type="submit" value="log in">
     </form>
   </md-content>
-
 </div>

--- a/app/index.sass
+++ b/app/index.sass
@@ -13,7 +13,4 @@
 @import './components/create-project-page/create-project-page.scss';
 @import './components/project-page/project-page.scss';
 @import './components/edit-project-page/edit-project-page.scss';
-
-md-toast {
-  position: fixed;
-}
+@import './components/ng-material-customs.scss';

--- a/app/index.sass
+++ b/app/index.sass
@@ -13,3 +13,7 @@
 @import './components/create-project-page/create-project-page.scss';
 @import './components/project-page/project-page.scss';
 @import './components/edit-project-page/edit-project-page.scss';
+
+md-toast {
+  position: fixed;
+}

--- a/app/models/bucket-model.coffee
+++ b/app/models/bucket-model.coffee
@@ -6,6 +6,7 @@ global.cobudgetApp.factory 'BucketModel', (BaseModel) ->
     @singular: 'bucket'
     @plural: 'buckets'
     @indices: ['groupId', 'userId']
+    @serializableAttributes: ['description', 'name', 'target', 'groupId']
 
     relationships: ->
       @hasMany 'comments', sortBy: 'createdAt', sortDesc: true
@@ -20,12 +21,4 @@ global.cobudgetApp.factory 'BucketModel', (BaseModel) ->
 
     openForFunding: ->
       @remote.postMember(@id,'open_for_funding', {target: @target, fundingClosesAt: @fundingClosesAt})
-    
-    # temp hack to allow post requests
-    create: ->
-      @remote.create
-        bucket:
-          description: @description
-          name: @name 
-          target: @target
-          group_id: @groupId
+  

--- a/app/models/group-model.coffee
+++ b/app/models/group-model.coffee
@@ -26,7 +26,3 @@ global.cobudgetApp.factory 'GroupModel', (BaseModel) ->
     membershipFor: (member) ->
       _.first _.filter @memberships(), (membership) ->
         membership.memberId == member.id
-
-    # personalFunds: ->
-
-    # totalFunds: ->

--- a/app/services/toast.coffee
+++ b/app/services/toast.coffee
@@ -5,7 +5,9 @@ global.cobudgetApp.factory 'Toast', ($mdToast, $location) ->
   new class Toast
 
     show: (msg) ->
-      $mdToast.show($mdToast.simple().content(msg))
+      toast = $mdToast.simple()
+        .content(msg)
+      $mdToast.show(toast)
 
     showAndRedirect: (msg, path) ->
       toast = $mdToast.simple()

--- a/app/services/toast.coffee
+++ b/app/services/toast.coffee
@@ -1,0 +1,7 @@
+null
+
+### @ngInject ###
+global.cobudgetApp.factory 'Toast', ($mdToast) ->
+  new class Toast
+    show: (msg) ->
+      $mdToast.show($mdToast.simple().content(msg))

--- a/app/services/toast.coffee
+++ b/app/services/toast.coffee
@@ -1,7 +1,18 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'Toast', ($mdToast) ->
+global.cobudgetApp.factory 'Toast', ($mdToast, $location) ->
   new class Toast
+
     show: (msg) ->
       $mdToast.show($mdToast.simple().content(msg))
+
+    showAndRedirect: (msg, path) ->
+      toast = $mdToast.simple()
+        .content(msg)
+        .action('VIEW')
+        .highlightAction(false)
+
+      $mdToast.show(toast).then (res) ->
+        if res == 'ok'
+          $location.path(path)


### PR DESCRIPTION
lots of small tweaks in this pull request:
- spent some time attempting to set up automatic redirects to the group page (if user logged in) and automatic redirect to the sign-in page (if user not logged in), but was a little too difficult and out of scope - so I'm going to table it for later. 
- with rob's help, created Toast service, which handles the displaying of Toast alerts with msgs and redirects. Toast alerts currently triggered by 1) creating a new draft, 2) editing an existing draft, + 3) opening a draft for funding
- with rob's help, fixed bug where group page wouldn't load on initial log-in
- with rob's help, fixed bug where .save() wasn't working on bucket-model
- renamed all '/groups/:groupId/projects/:projectId' routes to be non-nested ('/projects/:projectId')
- styled toast alerts to conform to derek's designs