### PR TITLE
Bug/screen jump

### DIFF
--- a/app/components/bucket-page/bucket-page.coffee
+++ b/app/components/bucket-page/bucket-page.coffee
@@ -5,11 +5,16 @@ module.exports =
   url: '/buckets/:bucketId'
   template: require('./bucket-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, Toast) ->
+    $scope.groupLoaded = false
+    $scope.contributionsLoaded = false
+    $scope.commentsLoaded = false
+
     groupId = global.cobudgetApp.currentGroupId
     bucketId = parseInt $stateParams.bucketId
 
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
+      $scope.groupLoaded = true
       $scope.currentMembership = group.membershipFor(CurrentUser())
 
     Records.buckets.findOrFetchById(bucketId).then (bucket) ->
@@ -18,8 +23,9 @@ module.exports =
       Records.contributions.fetchByBucketId(bucketId).then ->
         $scope.percentContributedByUser = bucket.percentContributedByUser(CurrentUser().id)
         $scope.percentNotContributedByUser = bucket.percentNotContributedByUser(CurrentUser().id)
+        $scope.contributionsLoaded = true
       Records.comments.fetchByBucketId(bucketId).then ->
-        window.scrollTo(0, 0)
+        $scope.commentsLoaded = true
 
     $scope.back = ->
       Toast.hide()

--- a/app/components/bucket-page/bucket-page.html
+++ b/app/components/bucket-page/bucket-page.html
@@ -1,3 +1,11 @@
+<div 
+  class="loading-bar" 
+  layout="column" 
+  layout-align="center center" 
+  ng-hide="groupLoaded && contributionsLoaded && commentsLoaded">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+</div>
+
 <div class="bucket-page" ng-show="groupLoaded && contributionsLoaded && commentsLoaded">
   <md-toolbar class="bucket-page__toolbar">
     <div class="md-toolbar-tools bucket-page__menu-bar">

--- a/app/components/bucket-page/bucket-page.html
+++ b/app/components/bucket-page/bucket-page.html
@@ -2,15 +2,19 @@
   <md-toolbar class="bucket-page__toolbar">
     <div class="md-toolbar-tools bucket-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings" ng-click="back()">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons bucket-page__menu-icon">arrow_back</i>
-        </div>
+        <ng-md-icon icon="arrow_back"
+          layout="column"
+          layout-align="center center"
+          class="bucket-page__menu-icon"
+        ></ng-md-icon>
       </md-button>
 
       <span class="bucket-page__personal-funds" layout="row" layout-align="start center" ng-if="status == 'live'">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons bucket-page__funds-icon">person</i>
-        </div>
+        <ng-md-icon icon="person"
+          layout="column"
+          layout-align="center center"
+          class="bucket-page__funds-icon"
+        ></ng-md-icon>
         <div layout="column" layout-align="center center">
           <span class="bucket-page__funds-overview-header">Your funds</span>
           <span class="bucket-page__funds-overview-amount">{{ currentMembership.balance() - contribution.amount | currency : group.currencySymbol : 0 }}</span>
@@ -24,9 +28,11 @@
       </span>
 
       <md-button class="md-icon-button bucket-page-menu-button" aria-label="More" ng-click="toggleStatus()">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons bucket-page__menu-icon">more_vert</i>
-        </div>
+        <ng-md-icon icon="more_vert"
+          layout="column"
+          layout-align="center center"
+          class="bucket-page__menu-icon"
+        ></ng-md-icon>
       </md-button>
     </div>
   </md-toolbar> 
@@ -102,12 +108,20 @@
         <div class="bucket-page__status-flagpoints" layout="row" layout-align="space-between center">
           <div class="bucket-page__status-flagpoint">
             <div layout="column" layout-align="center center" ng-show="status === 'draft'">
-              <i class="material-icons bucket-page__draft-icon">radio_button_on</i>
+              <ng-md-icon icon="radio_button_on"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__draft-icon"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-active">Idea</span>
             </div>
 
             <div layout="column" layout-align="center center" ng-hide="status === 'draft'">
-              <i class="material-icons bucket-page__status-icon-inactive">radio_button_off</i>
+              <ng-md-icon icon="radio_button_off"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__status-icon-inactive"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-inactive">Idea</span>
             </div>
           </div>
@@ -116,12 +130,20 @@
 
           <div class="bucket-page__status-flagpoint">
             <div layout="column" layout-align="center center" ng-show="status === 'live'">
-              <i class="material-icons bucket-page__live-icon">radio_button_on</i>
+              <ng-md-icon icon="radio_button_on"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__live-icon"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-active">Funding</span>
             </div>
 
             <div layout="column" layout-align="center center" ng-hide="status === 'live'">
-              <i class="material-icons bucket-page__status-icon-inactive">radio_button_off</i>
+              <ng-md-icon icon="radio_button_off"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__status-icon-inactive"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-inactive">Funding</span>
             </div>
           </div>
@@ -130,12 +152,20 @@
 
           <div class="bucket-page__status-flagpoint">
             <div layout="column" layout-align="center center" ng-show="status === 'funded'">
-              <i class="material-icons bucket-page__funded-icon">radio_button_on</i>
+              <ng-md-icon icon="radio_button_on"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__funded-icon"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-active">Funded</span>
             </div>
 
             <div layout="column" layout-align="center center" ng-hide="status === 'funded'">
-              <i class="material-icons bucket-page__status-icon-inactive">radio_button_off</i>
+              <ng-md-icon icon="radio_button_off"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__status-icon-inactive"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-inactive">Funded</span>
             </div>
           </div>
@@ -144,13 +174,22 @@
 
           <div class="bucket-page__status-flagpoint">
             <div layout="column" layout-align="center center" ng-show="status === 'done'">
-              <i class="material-icons bucket-page__done-icon">radio_button_on</i>
+              <ng-md-icon icon="radio_button_on"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__done-icon"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-active">Done</span>
             </div>
 
             <div layout="column" layout-align="center center" ng-hide="status === 'done'">
-              <i class="material-icons bucket-page__status-icon-inactive">radio_button_off</i>
+              <ng-md-icon icon="radio_button_off"
+                layout="column"
+                layout-align="center center"
+                class="bucket-page__status-icon-inactive"
+              ></ng-md-icon>
               <span class="bucket-page__status-flagpoint-text-inactive">Done</span>
+
             </div>
           </div>
         </div>
@@ -180,10 +219,12 @@
           </span>
           <span flex></span>
           <span>
-            <div layout="column" layout-align="center center">
-              <i class="material-icons bucket-page__comment-count-icon">messenger</i>
-              <div class="bucket-page__comment-count">{{ bucket.comments().length }}</div>
-            </div>
+            <ng-md-icon icon="messenger"
+              layout="column"
+              layout-align="center center"
+              class="bucket-page__comment-count-icon"
+            ></ng-md-icon>
+            <div class="bucket-page__comment-count">{{ bucket.comments().length }}</div>
           </span>
         </div>
 

--- a/app/components/bucket-page/bucket-page.html
+++ b/app/components/bucket-page/bucket-page.html
@@ -222,9 +222,10 @@
             <ng-md-icon icon="messenger"
               layout="column"
               layout-align="center center"
-              class="bucket-page__comment-count-icon"
+              ng-class="bucket.hasComments() ? 'bucket-page__comment-icon-active' : 'bucket-page__comment-icon-inactive'"
+
             ></ng-md-icon>
-            <div class="bucket-page__comment-count">{{ bucket.comments().length }}</div>
+            <div class="bucket-page__comment-count" ng-if="bucket.hasComments()">{{ bucket.comments().length }}</div>
           </span>
         </div>
 

--- a/app/components/bucket-page/bucket-page.html
+++ b/app/components/bucket-page/bucket-page.html
@@ -1,4 +1,4 @@
-<div class="bucket-page">
+<div class="bucket-page" ng-show="groupLoaded && contributionsLoaded && commentsLoaded">
   <md-toolbar class="bucket-page__toolbar">
     <div class="md-toolbar-tools bucket-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings" ng-click="back()">

--- a/app/components/bucket-page/bucket-page.scss
+++ b/app/components/bucket-page/bucket-page.scss
@@ -258,6 +258,7 @@
 }
 
 .bucket-page__comment {
+  @include wordWrap;
   background: $cobudget-light-grey;
 }
 

--- a/app/components/bucket-page/bucket-page.scss
+++ b/app/components/bucket-page/bucket-page.scss
@@ -16,6 +16,7 @@
 
 .bucket-page__menu-icon {
   @include fontGrande;
+  fill: white;
 }
 
 .bucket-page__personal-funds {
@@ -29,6 +30,7 @@
 .bucket-page__funds-icon {
   @include fontGrande;
   margin-right: 10px;
+  fill: white;
 }
 
 .bucket-page__edit-button {
@@ -198,23 +200,19 @@
 }
 
 .bucket-page__status-icon-inactive {
-  color: $grey-on-white;
+  fill: $grey-on-white;
 }
 
 .bucket-page__draft-icon {
-  color: $cobudget-gold;
+  fill: $cobudget-gold;
 }
 
 .bucket-page__live-icon {
-  color: $cobudget-lime;
+  fill: $cobudget-lime;
 }
 
 .bucket-page__funded-icon {
-  color: $cobudget-cyan;
-}
-
-.bucket-page__status-flagpoint-icon-inactive {
-  color: $grey-on-white;
+  fill: $cobudget-cyan;
 }
 
 .bucket-page__status-description {
@@ -240,8 +238,9 @@
 .bucket-page__comment-count {
   color: white;
   position: relative;
-  bottom: 23px;
   @include fontSmall;
+  left: 8px;
+  bottom: 22px;
 }
 
 .bucket-page__comment-count-icon {

--- a/app/components/bucket-page/bucket-page.scss
+++ b/app/components/bucket-page/bucket-page.scss
@@ -243,9 +243,15 @@
   bottom: 22px;
 }
 
-.bucket-page__comment-count-icon {
+.bucket-page__comment-icon-active {
   @include fontGrande;
 }
+
+.bucket-page__comment-icon-inactive {
+  @include fontGrande;
+  fill: $cobudget-grey;
+}
+
 
 .bucket-page md-input-container {
   padding: 0;

--- a/app/components/bucket-page/bucket-page.scss
+++ b/app/components/bucket-page/bucket-page.scss
@@ -239,7 +239,7 @@
   color: white;
   position: relative;
   @include fontSmall;
-  left: 8px;
+  text-align: center;
   bottom: 22px;
 }
 

--- a/app/components/bucket-page/bucket-page.scss
+++ b/app/components/bucket-page/bucket-page.scss
@@ -7,6 +7,7 @@
 .bucket-page__toolbar {
   background: $cobudget-gunmetal;
   position: fixed;
+  top: 0;
   color: white;
 }
 

--- a/app/components/create-bucket-page/create-bucket-page.coffee
+++ b/app/components/create-bucket-page/create-bucket-page.coffee
@@ -5,14 +5,15 @@ module.exports =
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
   controller: ($scope, Records, $location, Toast) ->
+    $scope.groupLoaded = false
 
     groupId = global.cobudgetApp.currentGroupId
 
-    $scope.bucket = Records.buckets.build()
-    $scope.bucket.groupId = groupId
+    $scope.bucket = Records.buckets.build(groupId: groupId)
 
     Records.groups.findOrFetchById(groupId).then (group) ->
       $scope.group = group
+      $scope.groupLoaded = true
       
     $scope.cancel = () ->
       $location.path("/groups/#{groupId}")

--- a/app/components/create-bucket-page/create-bucket-page.coffee
+++ b/app/components/create-bucket-page/create-bucket-page.coffee
@@ -1,6 +1,9 @@
 module.exports = 
   url: '/buckets/new'
   template: require('./create-bucket-page.html')
+  resolve: 
+    membershipsLoaded: ->
+      global.cobudgetApp.membershipsLoaded
   controller: ($scope, Records, $location, Toast) ->
 
     groupId = global.cobudgetApp.currentGroupId

--- a/app/components/create-bucket-page/create-bucket-page.html
+++ b/app/components/create-bucket-page/create-bucket-page.html
@@ -1,3 +1,11 @@
+<div 
+  class="loading-bar" 
+  layout="column" 
+  layout-align="center center" 
+  ng-hide="groupLoaded">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+</div>
+
 <div class="create-bucket-page" ng-show="groupLoaded">
   <md-toolbar class="md-whiteframe-z1 create-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">

--- a/app/components/create-bucket-page/create-bucket-page.html
+++ b/app/components/create-bucket-page/create-bucket-page.html
@@ -1,4 +1,4 @@
-<div class="create-bucket-page">
+<div class="create-bucket-page" ng-show="groupLoaded">
   <md-toolbar class="md-whiteframe-z1 create-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">
       <md-button class="md-icon-button" ng-click="cancel()" aria-label="cancel">

--- a/app/components/create-bucket-page/create-bucket-page.html
+++ b/app/components/create-bucket-page/create-bucket-page.html
@@ -2,9 +2,11 @@
   <md-toolbar class="md-whiteframe-z1 create-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">
       <md-button class="md-icon-button" ng-click="cancel()" aria-label="cancel">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons create-bucket-page__cancel-icon">close</i>
-        </div>
+        <ng-md-icon icon="close"
+          class="create-bucket-page__cancel-icon" 
+          layout="column" 
+          layout-align="center center"
+        ></ng-md-icon>
       </md-button>
       <span class="create-bucket-page__header-text">New Idea</span>
       <span flex></span>

--- a/app/components/create-bucket-page/create-bucket-page.scss
+++ b/app/components/create-bucket-page/create-bucket-page.scss
@@ -7,6 +7,7 @@
 
 .create-bucket-page__cancel-icon {
   @include fontGrande;
+  fill: white;
 }
 
 .create-bucket-page__header-text {

--- a/app/components/edit-bucket-page/edit-bucket-page.coffee
+++ b/app/components/edit-bucket-page/edit-bucket-page.coffee
@@ -1,6 +1,9 @@
 module.exports = 
   url: '/buckets/:bucketId/edit'
   template: require('./edit-bucket-page.html')
+  resolve: 
+    membershipsLoaded: ->
+      global.cobudgetApp.membershipsLoaded
   controller: ($scope, Records, $stateParams, $location, Toast) ->
     bucketId = parseInt $stateParams.bucketId
 

--- a/app/components/edit-bucket-page/edit-bucket-page.coffee
+++ b/app/components/edit-bucket-page/edit-bucket-page.coffee
@@ -5,10 +5,13 @@ module.exports =
     membershipsLoaded: ->
       global.cobudgetApp.membershipsLoaded
   controller: ($scope, Records, $stateParams, $location, Toast) ->
+    $scope.bucketLoaded = false
+
     bucketId = parseInt $stateParams.bucketId
 
     Records.buckets.findOrFetchById(bucketId).then (bucket) ->
       $scope.bucket = bucket
+      $scope.bucketLoaded = true
       # temp hack to get around target form number validation
       $scope.bucket.target = parseInt $scope.bucket.target
             

--- a/app/components/edit-bucket-page/edit-bucket-page.html
+++ b/app/components/edit-bucket-page/edit-bucket-page.html
@@ -1,4 +1,4 @@
-<div class="edit-bucket-page">
+<div class="edit-bucket-page" ng-show="bucketLoaded">
   <md-toolbar class="md-whiteframe-z1 edit-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">
       <md-button class="md-icon-button" ng-click="cancel()" aria-label="cancel">

--- a/app/components/edit-bucket-page/edit-bucket-page.html
+++ b/app/components/edit-bucket-page/edit-bucket-page.html
@@ -2,9 +2,11 @@
   <md-toolbar class="md-whiteframe-z1 edit-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">
       <md-button class="md-icon-button" ng-click="cancel()" aria-label="cancel">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons edit-bucket-page__cancel-icon">close</i>
-        </div>
+        <ng-md-icon icon="close"
+          class="edit-bucket-page__cancel-icon"
+          layout="column" 
+          layout-align="center center"
+        ></ng-md-icon>
       </md-button>
       <span class="edit-bucket-page__header-text">Edit {{ bucket.status == 'draft' ? 'Idea' : 'Bucket' }}</span>
       <span flex></span>

--- a/app/components/edit-bucket-page/edit-bucket-page.html
+++ b/app/components/edit-bucket-page/edit-bucket-page.html
@@ -1,3 +1,11 @@
+<div 
+  class="loading-bar" 
+  layout="column" 
+  layout-align="center center" 
+  ng-hide="bucketLoaded">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+</div>
+
 <div class="edit-bucket-page" ng-show="bucketLoaded">
   <md-toolbar class="md-whiteframe-z1 edit-bucket-page__toolbar" layout-align="column">
     <div class="md-toolbar-tools">

--- a/app/components/edit-bucket-page/edit-bucket-page.scss
+++ b/app/components/edit-bucket-page/edit-bucket-page.scss
@@ -7,6 +7,7 @@
 
 .edit-bucket-page__cancel-icon {
   @include fontGrande;
+  fill: white;
 }
 
 .edit-bucket-page__header-text {

--- a/app/components/group-page/group-page.coffee
+++ b/app/components/group-page/group-page.coffee
@@ -5,6 +5,9 @@ module.exports =
   url: '/groups/:groupId'
   template: require('./group-page.html')
   controller: ($scope, Records, $stateParams, $location, CurrentUser, Toast) ->
+    $scope.contributionsLoaded = false
+    $scope.commentsLoaded = false
+    $scope.membershipsLoaded = false
 
     groupId = parseInt($stateParams.groupId)
     global.cobudgetApp.currentGroupId = groupId
@@ -15,11 +18,12 @@ module.exports =
       $scope.currentMembership = group.membershipFor(CurrentUser())
       Records.buckets.fetchByGroupId(group.id).then (data) ->
         _.each data.buckets, (bucket) ->
-          Records.contributions.fetchByBucketId(bucket.id)
-          Records.comments.fetchByBucketId(bucket.id)
-      Records.memberships.fetchByGroupId(group.id)
-
-    window.scrollHeight = 0;
+          Records.contributions.fetchByBucketId(bucket.id).then ->
+            $scope.contributionsLoaded = true
+          Records.comments.fetchByBucketId(bucket.id).then ->
+            $scope.commentsLoaded = true
+      Records.memberships.fetchByGroupId(group.id).then ->
+        $scope.membershipsLoaded = true
 
     $scope.createBucket = ->
       $location.path("/buckets/new")

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -1,4 +1,4 @@
-<div class="group-page" ng-if="contributionsLoaded && commentsLoaded && membershipsLoaded">
+<div class="group-page" ng-show="contributionsLoaded && commentsLoaded && membershipsLoaded">
   <md-toolbar class="group-page__toolbar">
     <div class="md-toolbar-tools group-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings">

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -1,3 +1,11 @@
+<div 
+  class="loading-bar" 
+  layout="column" 
+  layout-align="center center" 
+  ng-hide="contributionsLoaded && commentsLoaded && membershipsLoaded">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+</div>
+
 <div class="group-page" ng-show="contributionsLoaded && commentsLoaded && membershipsLoaded">
   <md-toolbar class="group-page__toolbar">
     <div class="md-toolbar-tools group-page__menu-bar">

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -2,15 +2,27 @@
   <md-toolbar class="group-page__toolbar">
     <div class="md-toolbar-tools group-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings">
-        <ng-md-icon icon="menu" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
+        <ng-md-icon icon="menu" 
+          class="group-page__menu-icon" 
+          layout="column" 
+          layout-align="center center"
+        ></ng-md-icon>
       </md-button>
       <span class="group-page__group-name">{{ group.name }}</span>
       <span flex></span>
       <md-button class="md-icon-button group-page-menu-button" aria-label="Admin Panel" ng-if="currentMembership.isAdmin" ng-click="openAdminPanel()">
-        <ng-md-icon icon="local_pizza" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
+        <ng-md-icon icon="local_pizza" 
+          class="group-page__menu-icon" 
+          layout="column" 
+          layout-align="center center"
+        ></ng-md-icon>
       </md-button>      
       <md-button class="md-icon-button group-page-menu-button" aria-label="More">
-        <ng-md-icon icon="more_vert" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
+        <ng-md-icon icon="more_vert" 
+          class="group-page__menu-icon" 
+          layout="column" 
+          layout-align="center center"
+        ></ng-md-icon>
       </md-button>
     </div>
 
@@ -19,14 +31,22 @@
         <div class="group-page__funds-overview-header">Funds left</div>
         <div layout="row" layout-align="center center" class="group-page__funds-overview-content" >
           <div layout="row" class="group-page__personal-funds-container">
-            <ng-md-icon icon="person" class="group-page__funds-icon" layout="column" layout-align="center center"></ng-md-icon>
+            <ng-md-icon icon="person" 
+              class="group-page__funds-icon" 
+              layout="column" 
+              layout-align="center center"
+            ></ng-md-icon>
             <div layout="column" layout-align="center center">
               <span class="group-page__funds-overview-amount">{{ currentMembership.balance() | currency : group.currencySymbol : 0 }}</span>
             </div>
           </div>
           
           <div layout="row" class="group-page__group-funds-container">
-            <ng-md-icon icon="group" class="group-page__funds-icon" layout="column" layout-align="center center"></ng-md-icon>
+            <ng-md-icon icon="group" 
+              class="group-page__funds-icon" 
+              layout="column" 
+              layout-align="center center"
+            ></ng-md-icon>
             <div layout="column" layout-align="center center">
               <span class="group-page__funds-overview-amount">{{ group.balance | currency : group.currencySymbol : 0  }}</span>
             </div>
@@ -49,7 +69,11 @@
     </md-tabs>
 
     <md-button class="md-fab group-page__create-bucket-fab" ng-click="createBucket()">
-      <ng-md-icon icon="add" class="group-page__create-bucket-fab-icon" layout="column" layout-align="center center"></ng-md-icon>
+      <ng-md-icon icon="add" 
+        class="group-page__create-bucket-fab-icon" 
+        layout="column" 
+        layout-align="center center"
+      ></ng-md-icon>
     </md-button>
   </md-toolbar>
 

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -164,9 +164,12 @@
             </div>
             
             <md-button class="md-icon-button group-page__funder-more-button" aria-label="More" flex="10">
-              <div layout="column" layout-align="center center">
-                <i class="material-icons group-page__funder-more-button-icon">more_vert</i>
-              </div>
+              <ng-md-icon 
+                icon="more_vert" 
+                layout="column" 
+                layout-align="center center" 
+                class="group-page__funder-more-button-icon"
+              ></ng-md-icon>
             </md-button>
           </div>
         </md-list-item>

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -2,21 +2,15 @@
   <md-toolbar class="group-page__toolbar">
     <div class="md-toolbar-tools group-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons group-page__menu-icon">menu</i>
-        </div>
+        <ng-md-icon icon="menu" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
       </md-button>
       <span class="group-page__group-name">{{ group.name }}</span>
       <span flex></span>
       <md-button class="md-icon-button group-page-menu-button" aria-label="Admin Panel" ng-if="currentMembership.isAdmin" ng-click="openAdminPanel()">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons group-page__menu-icon">local_pizza</i>
-        </div>
+        <ng-md-icon icon="local_pizza" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
       </md-button>      
       <md-button class="md-icon-button group-page-menu-button" aria-label="More">
-        <div layout="column" layout-align="center center">
-          <i class="material-icons group-page__menu-icon">more_vert</i>
-        </div>
+        <ng-md-icon icon="more_vert" class="group-page__menu-icon" layout="column" layout-align="center center"></ng-md-icon>
       </md-button>
     </div>
 
@@ -25,18 +19,14 @@
         <div class="group-page__funds-overview-header">Funds left</div>
         <div layout="row" layout-align="center center" class="group-page__funds-overview-content" >
           <div layout="row" class="group-page__personal-funds-container">
-            <div layout="column" layout-align="center center">
-              <i class="material-icons group-page__funds-icon">person</i>
-            </div>
+            <ng-md-icon icon="person" class="group-page__funds-icon" layout="column" layout-align="center center"></ng-md-icon>
             <div layout="column" layout-align="center center">
               <span class="group-page__funds-overview-amount">{{ currentMembership.balance() | currency : group.currencySymbol : 0 }}</span>
             </div>
           </div>
           
           <div layout="row" class="group-page__group-funds-container">
-            <div layout="column" layout-align="center center">
-              <i class="material-icons group-page__funds-icon">group</i>
-            </div>
+            <ng-md-icon icon="group" class="group-page__funds-icon" layout="column" layout-align="center center"></ng-md-icon>
             <div layout="column" layout-align="center center">
               <span class="group-page__funds-overview-amount">{{ group.balance | currency : group.currencySymbol : 0  }}</span>
             </div>
@@ -59,9 +49,7 @@
     </md-tabs>
 
     <md-button class="md-fab group-page__create-bucket-fab" ng-click="createBucket()">
-      <div layout="column" layout-align="center center">
-        <i class="material-icons">add</i>
-      </div>
+      <ng-md-icon icon="add" class="group-page__create-bucket-fab-icon" layout="column" layout-align="center center"></ng-md-icon>
     </md-button>
   </md-toolbar>
 
@@ -105,10 +93,20 @@
           <div layout="column" flex class="group-page__draft-container">
             <span class="group-page__draft-title">{{ draftBucket.name }}</span>
             <span class="group-page__draft-author">created by {{ draftBucket.author().name }} {{ draftBucket.createdAt | timeFromNowInWords }} ago</span>
-            <div layout="column" layout-align="center center" class="group-page__comment-count-container">
-              <i ng-class="draftBucket.hasComments() ? 'material-icons group-page__comment-count-icon' : 'material-icons group-page__comment-count-icon-inactive'">messenger</i>
-              <div class="group-page__comment-count" ng-if="draftBucket.hasComments()">{{ draftBucket.comments().length }}</div>
+            
+            <div class="group-page__comment-count-container">
+              <ng-md-icon 
+                icon="messenger" 
+                layout="column" 
+                layout-align="center center" 
+                ng-class="draftBucket.hasComments() ? 'group-page__comment-icon-active' : 'group-page__comment-icon-inactive'"
+              ></ng-md-icon>
+              <div class="group-page__comment-count" ng-if="draftBucket.hasComments()">
+                {{ draftBucket.comments().length }}
+              </div>
             </div>
+
+
           </div>
         </md-list-item>
       </md-list>   

--- a/app/components/group-page/group-page.html
+++ b/app/components/group-page/group-page.html
@@ -1,4 +1,4 @@
-<div class="group-page">
+<div class="group-page" ng-if="contributionsLoaded && commentsLoaded && membershipsLoaded">
   <md-toolbar class="group-page__toolbar">
     <div class="md-toolbar-tools group-page__menu-bar">
       <md-button class="md-icon-button" aria-label="Settings">

--- a/app/components/group-page/group-page.scss
+++ b/app/components/group-page/group-page.scss
@@ -198,8 +198,8 @@
   @include fontTiny;
   position: relative;
   color: white;
-  left: 9px;
-  bottom: 21px;  
+  bottom: 21px;
+  text-align: center;
 }
 
 // funded projects

--- a/app/components/group-page/group-page.scss
+++ b/app/components/group-page/group-page.scss
@@ -14,6 +14,7 @@
 
 .group-page__menu-icon {
   @include fontGrande;
+  fill: white;
 }
 
 .group-page__group-name {
@@ -51,6 +52,7 @@
 .group-page__funds-icon {
   @include fontGrande;
   margin-right: 10px;
+  fill: white;
 }
 
 .group-page__funds-overview-amount {
@@ -83,6 +85,10 @@
   position: absolute;
   right: 10px;
   bottom: -30px;
+}
+
+.group-page__create-bucket-fab-icon {
+  fill: white;  
 }
 
 // content
@@ -179,20 +185,21 @@
   right: 4px;
 }
 
-.group-page__comment-count-icon {
+.group-page__comment-icon-active {
   @include fontGrande;
 }
 
-.group-page__comment-count-icon-inactive {
+.group-page__comment-icon-inactive {
   @include fontGrande;
-  color: $cobudget-grey;
+  fill: $cobudget-grey;
 }
 
 .group-page__comment-count {
-  color: white;
-  position: relative;
-  bottom: 23px;
   @include fontTiny;
+  position: relative;
+  color: white;
+  left: 8px;
+  bottom: 21px;  
 }
 
 // funded projects

--- a/app/components/group-page/group-page.scss
+++ b/app/components/group-page/group-page.scss
@@ -198,7 +198,7 @@
   @include fontTiny;
   position: relative;
   color: white;
-  left: 8px;
+  left: 9px;
   bottom: 21px;  
 }
 

--- a/app/components/mixins.scss
+++ b/app/components/mixins.scss
@@ -228,3 +228,10 @@ $large-height: 60px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+@mixin wordWrap {
+  word-break:     break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens:    auto;
+  hyphens:         auto;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -8,7 +8,7 @@
     
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
 
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <!-- <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"> -->
 
     <link rel="shortcut icon" href="/favicon.ico?v=1.0.0">
     <link rel="stylesheet" type="text/css" href="styles/angular-material.css">

--- a/app/index.js
+++ b/app/index.js
@@ -14,6 +14,7 @@ require('angular-material')
 require('angular-messages')
 require('ng-focus-if')
 require('angular-upload')
+require('angular-material-icons')
 
 if (process.env.NODE_ENV != 'production') {
   global.localStorage.debug = "*"
@@ -27,7 +28,8 @@ global.cobudgetApp = angular.module('cobudget', [
   'ngMessages',
   'ipCookie',
   'focus-if',
-  'lr.upload'
+  'lr.upload',
+  'ngMdIcons'
 ])
 .constant('config', require('app/configs/app'))
 

--- a/app/index.sass
+++ b/app/index.sass
@@ -2,9 +2,6 @@
 // and any config relating to the build.
 // app config (like bootstrap variables) are also here, before anything else.
 
-// feedback form
-// NOTE where should this code be?
-
 // ask mikey how to mass import shit
 @import './components/mixins.scss';
 @import './components/utilities.scss';
@@ -15,3 +12,25 @@
 @import './components/edit-bucket-page/edit-bucket-page.scss';
 @import './components/admin-page/admin-page.scss';
 @import './components/ng-material-customs.scss';
+
+// loading-bar
+
+.loading-bar {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%,-50%);
+}
+
+.loading-bar md-progress-circular .md-inner .md-left .md-half-circle {
+  border-left-color: $cobudget-orange;
+}
+
+.loading-bar md-progress-circular .md-inner .md-right .md-half-circle {
+  border-right-color: $cobudget-green;
+}
+
+.loading-bar md-progress-circular .md-inner .md-left .md-half-circle, 
+.loading-bar md-progress-circular .md-inner .md-right .md-half-circle {
+  border-top-color: $cobudget-orange;
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "angular-autoselect": "^0.3.2",
     "angular-cookie": "ivpusic/angular-cookie#v4.0.9",
     "angular-material": "^0.10.0",
+    "angular-material-icons": "^0.6.0",
     "angular-messages": "^1.4.3",
     "angular-sanitize": "^1.3.8",
     "angular-ui-router": "^0.2.11",


### PR DESCRIPTION
before, when pages were loading, the screen moved quite a bit as things loaded. 

in this pull request, i've stopped using a CDN for our icons, and have instead installed the 'angular-material-icons' node module so our icons are stored locally. this reduces load time by a significant amount. i've also added some code in the controllers / templates to display the page only when the data it depends on has loaded. while the data loads, a nice looking progress bar is displayed atop a white background.

while working on this, i also fixed a few small ui bugs. 
1. adding word-wrap to comments.
2. properly aligning comment-counts inside their icons
3. fixing the top toolbar on the bucket-page, so that when trying to fund a bucket, it sticks to the top of the screen