### PR TITLE
Feature/create account flow

### DIFF
--- a/app/components/confirm-account-page/confirm-account-page.coffee
+++ b/app/components/confirm-account-page/confirm-account-page.coffee
@@ -16,6 +16,12 @@ module.exports =
         name: formData.name        
         password: formData.password
         confirmation_token: $scope.confirmationToken        
-      Records.users.confirmAccount(params).then ->
-        Toast.show('Your account is set up! Please log in to continue.')
-        $location.path('/')
+      Records.users.confirmAccount(params)
+        .then ->
+          Toast.show('Your account is set up! Please log in to continue.')
+          $location.search('confirmation_token', null)
+          $location.path('/')
+        .catch ->
+          Toast.show('This token has expired. Please log in to continue')
+          $location.search('confirmation_token', null)
+          $location.path('/')

--- a/app/components/confirm-account-page/confirm-account-page.coffee
+++ b/app/components/confirm-account-page/confirm-account-page.coffee
@@ -1,0 +1,11 @@
+module.exports =
+  url: '/confirm_account?confirmation_token'
+  template: require('./confirm-account-page.html')
+  controller: ($scope, $location, $stateParams, Records) ->
+
+    $scope.userConfirmingAccount = false
+
+    $scope.confirmationToken = $stateParams.confirmation_token
+
+    $scope.confirmAccount = (formData) ->
+      console.log('formData: ', formData)

--- a/app/components/confirm-account-page/confirm-account-page.coffee
+++ b/app/components/confirm-account-page/confirm-account-page.coffee
@@ -4,12 +4,12 @@ module.exports =
   controller: ($scope, $location, $stateParams, Records, ipCookie, Toast) ->
 
     $scope.userConfirmingAccount = false
-
-    ipCookie.remove('currentGroupId')
-    ipCookie.remove('currentUserId')
-    ipCookie.remove('initialRequestPath')
-
     $scope.confirmationToken = $stateParams.confirmation_token
+
+    $scope.redirectToLogin = () ->
+      $location.search('confirmation_token', null)
+      ipCookie.remove('currentUserId')
+      $location.path('/')
 
     $scope.confirmAccount = (formData) ->
       params = 
@@ -19,9 +19,7 @@ module.exports =
       Records.users.confirmAccount(params)
         .then ->
           Toast.show('Your account is set up! Please log in to continue.')
-          $location.search('confirmation_token', null)
-          $location.path('/')
+          $scope.redirectToLogin()
         .catch ->
           Toast.show('This token has expired. Please log in to continue')
-          $location.search('confirmation_token', null)
-          $location.path('/')
+          $scope.redirectToLogin()

--- a/app/components/confirm-account-page/confirm-account-page.coffee
+++ b/app/components/confirm-account-page/confirm-account-page.coffee
@@ -1,11 +1,21 @@
 module.exports =
   url: '/confirm_account?confirmation_token'
   template: require('./confirm-account-page.html')
-  controller: ($scope, $location, $stateParams, Records) ->
+  controller: ($scope, $location, $stateParams, Records, ipCookie, Toast) ->
 
     $scope.userConfirmingAccount = false
+
+    ipCookie.remove('currentGroupId')
+    ipCookie.remove('currentUserId')
+    ipCookie.remove('initialRequestPath')
 
     $scope.confirmationToken = $stateParams.confirmation_token
 
     $scope.confirmAccount = (formData) ->
-      console.log('formData: ', formData)
+      params = 
+        name: formData.name        
+        password: formData.password
+        confirmation_token: $scope.confirmationToken        
+      Records.users.confirmAccount(params).then ->
+        Toast.show('Your account is set up! Please log in to continue.')
+        $location.path('/')

--- a/app/components/confirm-account-page/confirm-account-page.html
+++ b/app/components/confirm-account-page/confirm-account-page.html
@@ -1,0 +1,36 @@
+<div 
+  class="loading-bar" 
+  layout="column" 
+  layout-align="center center" 
+  ng-show="userConfirmingAccount">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+</div>
+
+<div class="confirm-account-page" ng-hide="userConfirmingAccount">
+  <md-toolbar class="md-primary confirm-account-page__toolbar">
+    <h1 class="md-toolbar-tools confirm-account-page__heading" layout-align="center">Confirm your Account</h1>
+  </md-toolbar>
+
+  <md-content layout-padding class="confirm-account-page__content">
+    <form name="newUserForm" ng-submit="confirmAccount(formData)">
+      <md-input-container>
+        <label>name</label>
+        <input required name="name" type="text" ng-model="formData.name">
+        <div ng-messages="newUserForm.name.$error">
+          <div ng-message="required">This is required.</div>
+        </div>
+      </md-input-container>
+
+      <md-input-container>
+        <label>new password</label>
+        <input minlength="8" required name="password" type="password" ng-model="formData.password">
+        <div ng-messages="newUserForm.password.$error">
+          <div ng-message="required">This is required.</div>
+          <div ng-message="minlength">Password must be at least 8 characters long.</div>
+        </div>
+      </md-input-container>
+
+      <input type="submit" value="submit">
+    </form>
+  </md-content>
+</div>

--- a/app/components/confirm-account-page/confirm-account-page.scss
+++ b/app/components/confirm-account-page/confirm-account-page.scss
@@ -1,0 +1,13 @@
+.confirm-account-page__toolbar {
+  background: $cobudget-gunmetal;
+  color: white;
+}
+
+.confirm-account-page__content {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.confirm-account-page__heading {
+  @include fontGrande;
+}

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -1,7 +1,7 @@
 module.exports = 
   url: '/'
   template: require('./welcome-page.html')
-  controller: ($scope, $auth, $location, Records, $rootScope, ipCookie) ->
+  controller: ($scope, $auth, $location, Records, ipCookie) ->
 
     $scope.userSigningIn = false
 

--- a/app/components/welcome-page/welcome-page.coffee
+++ b/app/components/welcome-page/welcome-page.coffee
@@ -20,6 +20,7 @@ module.exports =
           $location.path("/groups/#{ipCookie('currentGroupId')}")
       else
         $location.path(ipCookie('initialRequestPath'))
+        ipCookie.remove('initialRequestPath')
 
     $scope.$on 'auth:validation-success', (event, user) ->
       $scope.redirectToGroupPage(user) 

--- a/app/index.sass
+++ b/app/index.sass
@@ -11,6 +11,7 @@
 @import './components/bucket-page/bucket-page.scss';
 @import './components/edit-bucket-page/edit-bucket-page.scss';
 @import './components/admin-page/admin-page.scss';
+@import './components/confirm-account-page/confirm-account-page.scss';
 @import './components/ng-material-customs.scss';
 
 // loading-bar

--- a/app/records-interfaces/user-records-interface.coffee
+++ b/app/records-interfaces/user-records-interface.coffee
@@ -4,6 +4,6 @@ global.cobudgetApp.factory 'UserRecordsInterface', (config, BaseRecordsInterface
     constructor: (recordStore) ->
       @baseConstructor recordStore
       @remote.apiPrefix = config.apiPrefix
-    fetchMe: ->
-      @fetch
-        path: 'me'
+
+    confirmAccount: (params)->
+      @remote.post('confirm_account', params)

--- a/app/routes.coffee
+++ b/app/routes.coffee
@@ -9,3 +9,4 @@ global.cobudgetApp.config ($stateProvider, $urlRouterProvider) ->
     .state 'bucket', require('app/components/bucket-page/bucket-page.coffee')
     .state 'edit-bucket', require('app/components/edit-bucket-page/edit-bucket-page.coffee')
     .state 'admin', require('app/components/admin-page/admin-page.coffee')
+    .state 'confirm-account', require('app/components/confirm-account-page/confirm-account-page.coffee')

--- a/app/services/authenticate-user.coffee
+++ b/app/services/authenticate-user.coffee
@@ -5,9 +5,9 @@ global.cobudgetApp.factory 'AuthenticateUser', (Records, ipCookie, Toast, $locat
   () ->
     deferred = $q.defer()
 
-    if ipCookie('currentUserId')
+    if ipCookie('currentUserId') # if currentUserId still in session
       Records.memberships.fetchMyMemberships()
-        .then (data) ->
+        .then (data) -> # user logged in
           if groupId = parseInt($stateParams.groupId)
             if !(_.find data.groups, (group) -> group.id == groupId) 
               Toast.show('The group you were trying to access is private, please sign in to continue')
@@ -24,14 +24,13 @@ global.cobudgetApp.factory 'AuthenticateUser', (Records, ipCookie, Toast, $locat
                 $location.path('/')
                 deferred.reject()
           deferred.resolve(CurrentUser())
-        .catch (data) ->
+        .catch (data) -> # user not logged in
           Toast.show('Please log in to continue')
           ipCookie.remove('currentUserId')
           ipCookie.remove('currentGroupId')
-          ipCookie.remove('initialRequestPath')
           $location.path('/')
           deferred.reject()
-    else
+    else # if currentUserId not in session
       ipCookie('initialRequestPath', $location.path())
       Toast.show('You must sign in to continue')
       $location.path('/')


### PR DESCRIPTION
this pull request was made in conjunction with this one: https://github.com/cobudget/cobudget-api/pull/88

here on the UI, i've created a new 'confirm-account-page' component. when a user receives an invitation email with a special link containing a confirmation_token, they are redirected to this 'confirm-account-page' which contains a simple form with inputs for name and email. when the form is submitted, the user is redirected to the login page. 

if the form is submitted with a stale confirmation_token, the API does nothing, returns status 401, and the user is redirected to the login page with a little notification informing them that the token doesn't exist anymore.