### PR TITLE
Feature/email digest

### DIFF
--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -1,22 +1,25 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.run ($rootScope, Records, $q, $location, $auth, Toast, $window) ->
+global.cobudgetApp.run ($auth, CurrentUser, $location, $q, Records, $rootScope, Toast, $window) ->
 
   membershipsLoadedDeferred = $q.defer()
   global.cobudgetApp.membershipsLoaded = membershipsLoadedDeferred.promise
 
   $rootScope.$on 'auth:validation-success', (ev, user) ->
-    global.cobudgetApp.currentUserId = user.id    
+    global.cobudgetApp.currentUserId = user.id
     Records.memberships.fetchMyMemberships().then ->
       membershipsLoadedDeferred.resolve()
 
   $rootScope.$on 'auth:login-success', (ev, user) ->
     global.cobudgetApp.currentUserId = user.id
     Records.memberships.fetchMyMemberships().then (data) ->
+      if CurrentUser().utcOffset != moment().utcOffset()
+        Records.users.updateProfile(utc_offset: moment().utcOffset()).then (data) ->
+      membershipsLoadedDeferred.resolve()
+      
       # during invite new group flow, user created and logged in without having a group yet
       # so we perform this quick check
-      membershipsLoadedDeferred.resolve()
       if data.groups
         groupId = data.groups[0].id
         $location.path("/groups/#{groupId}")

--- a/app/components/create-bucket-page/create-bucket-page.coffee
+++ b/app/components/create-bucket-page/create-bucket-page.coffee
@@ -6,13 +6,14 @@ module.exports =
       global.cobudgetApp.membershipsLoaded
   url: '/buckets/new'
   template: require('./create-bucket-page.html')
-  controller: ($scope, Records, $location, Toast, CurrentUser, $window) ->
-    
+  controller: (CurrentUser, Error, $location, Records, $scope, Toast) ->
+
     $scope.accessibleGroups = CurrentUser().groups()
     $scope.bucket = Records.buckets.build()
 
     $scope.cancel = () ->
-      $window.history.back()
+      group = CurrentUser().primaryGroup()
+      $location.path("/groups/#{group.id}")
 
     $scope.done = () ->
       if $scope.bucketForm.$valid

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -16,4 +16,4 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
       @recordStore.groups.find(groupIds)
 
     primaryGroup: ->
-      @groups[0]
+      @groups()[0]

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -14,3 +14,6 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
       groupIds = _.map @memberships(), (membership) ->
         membership.groupId
       @recordStore.groups.find(groupIds)
+
+    primaryGroup: ->
+      @groups[0]

--- a/app/records-interfaces/membership-records-interface.coffee
+++ b/app/records-interfaces/membership-records-interface.coffee
@@ -10,8 +10,6 @@ global.cobudgetApp.factory 'MembershipRecordsInterface', (config, BaseRecordsInt
     fetchMyMemberships: ->
       @fetch
         path: 'my_memberships'
-        params:
-          utc_offset: moment().utcOffset()
     fetchByGroupId: (groupId) ->
       @fetch
         params:

--- a/app/records-interfaces/membership-records-interface.coffee
+++ b/app/records-interfaces/membership-records-interface.coffee
@@ -10,6 +10,8 @@ global.cobudgetApp.factory 'MembershipRecordsInterface', (config, BaseRecordsInt
     fetchMyMemberships: ->
       @fetch
         path: 'my_memberships'
+        params:
+          utc_offset: moment().utcOffset()
     fetchByGroupId: (groupId) ->
       @fetch
         params:

--- a/app/records-interfaces/user-records-interface.coffee
+++ b/app/records-interfaces/user-records-interface.coffee
@@ -13,3 +13,6 @@ global.cobudgetApp.factory 'UserRecordsInterface', (config, BaseRecordsInterface
 
     resetPassword: (params) ->
       @remote.post('reset_password', params)
+
+    updateProfile: (params) ->
+      @remote.post('update_profile', user: params)

--- a/app/services/current-user.coffee
+++ b/app/services/current-user.coffee
@@ -1,6 +1,6 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'CurrentUser', (Records, ipCookie) ->
+global.cobudgetApp.factory 'CurrentUser', (Records) ->
   ->
     Records.users.find(global.cobudgetApp.currentUserId)

--- a/app/services/user-can.coffee
+++ b/app/services/user-can.coffee
@@ -1,7 +1,7 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'UserCan', (Toast, $location, $q, Records) ->
+global.cobudgetApp.factory 'UserCan', ($location, $q, Records, Toast) ->
   new class UserCan
 
     viewGroup: (group) ->
@@ -26,3 +26,4 @@ global.cobudgetApp.factory 'UserCan', (Toast, $location, $q, Records) ->
         memberId: global.cobudgetApp.currentUserId
       })
       validMemberships.length == 0
+

--- a/app/services/user-can.coffee
+++ b/app/services/user-can.coffee
@@ -26,4 +26,3 @@ global.cobudgetApp.factory 'UserCan', ($location, $q, Records, Toast) ->
         memberId: global.cobudgetApp.currentUserId
       })
       validMemberships.length == 0
-

--- a/config/staging.js
+++ b/config/staging.js
@@ -1,3 +1,3 @@
 module.exports = {
-  apiPrefix: "https://cobudget-beta-api.herokuapp.com/api/v1"
+  apiPrefix: "https://staging-cobudget-api.herokuapp.com/api/v1"
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,16 @@
     "test": "(export NODE_ENV=test; npm run test-spec && npm run test-e2e)",
     "build": "gulp build",
     "develop": "gulp develop",
-    "stage-cname": "cp app/assets/CNAME.stage app/assets/CNAME",
-    "stage": "(export NODE_ENV=staging; npm run stage-cname && gulp branch && git push origin gh-pages -f)",
+
     "set-remote": "git remote add deploy-beta git@github.com:cobudget/beta.cobudget.co",
     "deploy-cname": "cp app/assets/CNAME.deploy app/assets/CNAME",
     "deploy-push": "git push deploy-beta gh-pages -f",
-    "deploy": "(export NODE_ENV=production; npm run deploy-cname && gulp branch && npm run deploy-push)"
+    "deploy": "(export NODE_ENV=production; npm run deploy-cname && gulp branch && npm run deploy-push)",
+
+    "set-remote-stage": "git remote add stage-beta git@github.com:cobudget/staging.cobudget.co",
+    "stage-cname": "cp app/assets/CNAME.stage app/assets/CNAME",
+    "stage-push": "git push stage-beta gh-pages -f",
+    "stage": "(export NODE_ENV=staging; npm run stage-cname && gulp branch && npm run stage-push)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this PR corresponds with this one: https://github.com/cobudget/cobudget-api/pull/94 on the api.

in this PR:
- when user logs in, their `utc_offset` is updated on the server if if has changed since their last login.
- npm scripts added to deploy to staging server
- staging server api endpoint updated
- `create-bucket-page`s `cancel` button redirects to the group page for the user's primary group.
