### PR TITLE
Hotfix/create bucket page cancel btn

### DIFF
--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -1,7 +1,7 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.run ($auth, CurrentUser, $location, $q, Records, $rootScope, Toast, $window) ->
+global.cobudgetApp.run ($auth, CurrentUser, ipCookie, $location, $q, Records, $rootScope, Toast, $window) ->
 
   membershipsLoadedDeferred = $q.defer()
   global.cobudgetApp.membershipsLoaded = membershipsLoadedDeferred.promise
@@ -42,3 +42,7 @@ global.cobudgetApp.run ($auth, CurrentUser, $location, $q, Records, $rootScope, 
       $location.path('/')
     else
       $window.location.reload()
+
+  $rootScope.$on '$stateChangeSuccess', (e, toState, toParams, fromState, fromParams) -> 
+    if toState.url == '/groups/:groupId'
+      ipCookie('currentGroupId', toParams.groupId)

--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -12,12 +12,12 @@ global.cobudgetApp.run ($auth, CurrentUser, ipCookie, $location, $q, Records, $r
       membershipsLoadedDeferred.resolve()
 
   $rootScope.$on 'auth:login-success', (ev, user) ->
+    ipCookie.remove('currentGroupId');
     global.cobudgetApp.currentUserId = user.id
     Records.memberships.fetchMyMemberships().then (data) ->
       if CurrentUser().utcOffset != moment().utcOffset()
         Records.users.updateProfile(utc_offset: moment().utcOffset()).then (data) ->
       membershipsLoadedDeferred.resolve()
-      
       # during invite new group flow, user created and logged in without having a group yet
       # so we perform this quick check
       if data.groups

--- a/app/components/create-bucket-page/create-bucket-page.coffee
+++ b/app/components/create-bucket-page/create-bucket-page.coffee
@@ -6,14 +6,17 @@ module.exports =
       global.cobudgetApp.membershipsLoaded
   url: '/buckets/new'
   template: require('./create-bucket-page.html')
-  controller: (CurrentUser, Error, $location, Records, $scope, Toast) ->
-
+  controller: (CurrentUser, Error, ipCookie, $location, Records, $scope, Toast, $window) ->
     $scope.accessibleGroups = CurrentUser().groups()
     $scope.bucket = Records.buckets.build()
 
     $scope.cancel = () ->
-      group = CurrentUser().primaryGroup()
-      $location.path("/groups/#{group.id}")
+      if ipCookie('currentGroupId')
+        groupId = ipCookie('currentGroupId')
+      else
+        groupId = CurrentUser().primaryGroup().id
+
+      $location.path("/groups/#{groupId}")
 
     $scope.done = () ->
       if $scope.bucketForm.$valid


### PR DESCRIPTION
whenever user visits a `group-page`, the `id` of that `group` is stored in a cookie as `currentGroupId`

on the `create-bucket-page`, if there is a `currentGroupId` stored in the cookie, pressing the cancel btn redirects to that `group-page`. otherwise, it redirects to the `group-page` of the user's `primaryGroup()`

on `login-success`, the `currentGroupId` cookie is cleared, so as to prevent conflicts if someone logs into a different account on the same session.