### PR TITLE
Feature/admin can change user funds

### DIFF
--- a/app/components/globals.scss
+++ b/app/components/globals.scss
@@ -9,3 +9,9 @@ md-toast > span.ng-binding {
 md-toast > button.md-button {
   color: $cobudget-jade;
 }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/app/components/globals.scss
+++ b/app/components/globals.scss
@@ -10,8 +10,12 @@ md-toast > button.md-button {
   color: $cobudget-jade;
 }
 
-input[type=number]::-webkit-inner-spin-button,
-input[type=number]::-webkit-outer-spin-button {
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield !important;
 }

--- a/app/components/mixins.scss
+++ b/app/components/mixins.scss
@@ -189,6 +189,7 @@ $cobudget-red: #FF0045;
 $grey-on-white: #767676;
 $cobudget-gunmetal: #243239;
 $cobudget-happy-blue: #00B8D4;
+$cobudget-dark-grey: #454545;
 
 $small-height: 36px;
 $medium-height: 48px;

--- a/app/components/mixins.scss
+++ b/app/components/mixins.scss
@@ -190,6 +190,7 @@ $grey-on-white: #767676;
 $cobudget-gunmetal: #243239;
 $cobudget-happy-blue: #00B8D4;
 $cobudget-dark-grey: #454545;
+$cobudget-pink: #FF85B7;
 
 $small-height: 36px;
 $medium-height: 48px;

--- a/app/directives/bucket-page-progress-card/bucket-page-progress-card.scss
+++ b/app/directives/bucket-page-progress-card/bucket-page-progress-card.scss
@@ -36,7 +36,7 @@
 
 .bucket-page__progress-bar-secondary {
   position: absolute;
-  height: 100%; 
+  height: 100%;
   left: 0;
   background: $cobudget-green;
   z-index: 1;
@@ -55,7 +55,7 @@
 }
 
 .bucket-page__progress-unit {
-  display: block;  
+  display: block;
   @include fontSmall;
   color: $grey-on-white;
 }
@@ -74,8 +74,8 @@
   padding-bottom: 0;
 }
 
-.bucket-page input[type=number]::-webkit-inner-spin-button, 
+.bucket-page input[type=number]::-webkit-inner-spin-button,
 .bucket-page input[type=number]::-webkit-outer-spin-button {
-  -webkit-appearance: none; 
-  margin: 0; 
+  -webkit-appearance: none;
+  margin: 0;
 }

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -73,8 +73,11 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
               allocation = Records.allocations.build(params)
               allocation.save()
                 .then (res) ->
-                  console.log('res: ', res)
+                  Records.memberships.findOrFetchById($scope.managedMembership.id)
+                  Dialog.alert(title: 'Success!')
                 .catch (err) ->
-                  console.log('err: ', err)
+                  Dialog.alert(title: 'Error!')
+                .finally ->
+                  $scope.cancel()
 
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -36,15 +36,16 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
                 ).then ->
                   $window.location.reload()
 
-      $scope.openManageFundsDialog = ->
+      $scope.openManageFundsDialog = (funderMembership) ->
         Dialog.custom
           scope: $scope
           template: require('./../../directives/group-page-funders/manage-funds-dialog.tmpl.html')
           controller: ($scope) ->
             $scope.mode = 'add'
+            $scope.managedMembership = funderMembership
+            $scope.managedMember = funderMembership.member()
 
             $scope.setMode = (mode) ->
               $scope.mode = mode
-
 
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -40,14 +40,11 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
         Dialog.custom
           scope: $scope
           template: require('./../../directives/group-page-funders/manage-funds-dialog.tmpl.html')
-          controller: ($mdDialog, $scope) ->
+          controller: ($mdDialog, $scope, Records) ->
             $scope.formData = {}
             $scope.mode = 'add'
             $scope.managedMembership = funderMembership
             $scope.managedMember = funderMembership.member()
-
-            $scope.cancel = ->
-              $mdDialog.cancel()
 
             $scope.setMode = (mode) ->
               $scope.mode = mode
@@ -63,5 +60,21 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
 
             $scope.isValidForm = ->
               ($scope.mode == 'add' && $scope.formData.allocationAmount) || ($scope.mode == 'change' && $scope.formData.newBalance)
+
+            $scope.cancel = ->
+              $mdDialog.cancel()
+
+            $scope.createAllocation = ->
+              if $scope.mode == 'add'
+                amount = $scope.formData.allocationAmount
+              if $scope.mode == 'change'
+                amount = $scope.formData.newBalance - $scope.managedMembership.balance()
+              params = {groupId: $scope.group.id, userId: $scope.managedMember.id, amount: amount }
+              allocation = Records.allocations.build(params)
+              allocation.save()
+                .then (res) ->
+                  console.log('res: ', res)
+                .catch (err) ->
+                  console.log('err: ', err)
 
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -41,11 +41,17 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
           scope: $scope
           template: require('./../../directives/group-page-funders/manage-funds-dialog.tmpl.html')
           controller: ($scope) ->
+            $scope.formData = {}
             $scope.mode = 'add'
             $scope.managedMembership = funderMembership
             $scope.managedMember = funderMembership.member()
 
             $scope.setMode = (mode) ->
               $scope.mode = mode
+
+            $scope.normalizeAllocationAmount = ->
+              allocationAmount = $scope.formData.allocationAmount || 0
+              if allocationAmount + $scope.managedMembership.balance() < 0
+                $scope.formData.allocationAmount = -$scope.managedMembership.balance()
 
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -54,4 +54,11 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
               if allocationAmount + $scope.managedMembership.balance() < 0
                 $scope.formData.allocationAmount = -$scope.managedMembership.balance()
 
+            $scope.normalizeNewBalance = ->
+              if $scope.formData.newBalance < 0
+                $scope.formData.newBalance = 0
+
+            $scope.isValidForm = ->
+              ($scope.mode == 'add' && $scope.formData.allocationAmount) || ($scope.mode == 'change' && $scope.formData.newBalance)
+
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -31,9 +31,20 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
               membership.archive().then ->
                 LoadBar.stop()
                 Dialog.alert(
-                  title: 'Success!' 
+                  title: 'Success!'
                   content: "#{$scope.member.name} was removed from #{$scope.group.name}"
                 ).then ->
                   $window.location.reload()
+
+      $scope.openManageFundsDialog = ->
+        Dialog.custom
+          scope: $scope
+          template: require('./../../directives/group-page-funders/manage-funds-dialog.tmpl.html')
+          controller: ($scope) ->
+            $scope.mode = 'add'
+
+            $scope.setMode = (mode) ->
+              $scope.mode = mode
+
 
       return

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -40,11 +40,14 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
         Dialog.custom
           scope: $scope
           template: require('./../../directives/group-page-funders/manage-funds-dialog.tmpl.html')
-          controller: ($scope) ->
+          controller: ($mdDialog, $scope) ->
             $scope.formData = {}
             $scope.mode = 'add'
             $scope.managedMembership = funderMembership
             $scope.managedMember = funderMembership.member()
+
+            $scope.cancel = ->
+              $mdDialog.cancel()
 
             $scope.setMode = (mode) ->
               $scope.mode = mode

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -26,7 +26,7 @@
 
           <md-menu-content width="3">
             <md-menu-item>
-              <md-button ng-click="openManageFundsDialog()">
+              <md-button ng-click="openManageFundsDialog(funderMembership)">
                 <div layout="row" layout-align="start center">
                   <div layout="column" layout-align="center center" class="group-page__manage-funds-icon">
                     <div>{{ group.currencySymbol }}</div>

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -38,13 +38,29 @@
 
             <md-menu-item>
               <md-button ng-click="toggleMemberAdmin(funderMembership)">
-                <span md-menu-align-target>{{ funderMembership.isAdmin ? "Undo" : "Make" }} Admin</span>
+                <div layout="row" layout-align="start center">
+                  <ng-md-icon
+                    icon="portrait"
+                    layout="column"
+                    layout-align="center center"
+                    class="group-page__funder-more-menu-item-icon"
+                  ></ng-md-icon>
+                  <span md-menu-align-target class="group-page__funder-more-menu-item-label">{{ funderMembership.isAdmin ? "Undo" : "Make" }} Admin</span>
+                </div>
               </md-button>
             </md-menu-item>
 
             <md-menu-item ng-if="funderMembership.id != membership.id">
               <md-button ng-click="removeMembership(funderMembership)">
-                <span md-menu-align-target>Remove User</span>
+                <div layout="row" layout-align="start center">
+                  <ng-md-icon
+                    icon="cancel"
+                    layout="column"
+                    layout-align="center center"
+                    class="group-page__funder-more-menu-item-icon"
+                  ></ng-md-icon>
+                  <span md-menu-align-target class="group-page__funder-more-menu-item-label">Remove User</span>
+                </div>
               </md-button>
             </md-menu-item>
           </md-menu-content>

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -23,8 +23,19 @@
               class="group-page__funder-more-button-icon"
             ></ng-md-icon>
           </md-button>
-        
-          <md-menu-content width="2">
+
+          <md-menu-content width="3">
+            <md-menu-item>
+              <md-button ng-click="">
+                <div layout="row" layout-align="start center">
+                  <div layout="column" layout-align="center center" class="group-page__manage-funds-icon">
+                    <div>{{ group.currencySymbol }}</div>
+                  </div>
+                  <span md-menu-align-target class="group-page__funder-more-menu-item-label">Manage Funds</span>
+                </div>
+              </md-button>
+            </md-menu-item>
+
             <md-menu-item>
               <md-button ng-click="toggleMemberAdmin(funderMembership)">
                 <span md-menu-align-target>{{ funderMembership.isAdmin ? "Undo" : "Make" }} administrator</span>

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -26,7 +26,7 @@
 
           <md-menu-content width="3">
             <md-menu-item>
-              <md-button ng-click="">
+              <md-button ng-click="openManageFundsDialog()">
                 <div layout="row" layout-align="start center">
                   <div layout="column" layout-align="center center" class="group-page__manage-funds-icon">
                     <div>{{ group.currencySymbol }}</div>

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -16,10 +16,10 @@
 
         <md-menu md-offset="0 -7" class="group-page__funder-more-menu" ng-if="membership.isAdmin">
           <md-button class="md-icon-button group-page__funder-more-button" aria-label="More" ng-click="$mdOpenMenu($event)">
-            <ng-md-icon 
-              icon="more_vert" 
-              layout="column" 
-              layout-align="center center" 
+            <ng-md-icon
+              icon="more_vert"
+              layout="column"
+              layout-align="center center"
               class="group-page__funder-more-button-icon"
             ></ng-md-icon>
           </md-button>
@@ -38,13 +38,13 @@
 
             <md-menu-item>
               <md-button ng-click="toggleMemberAdmin(funderMembership)">
-                <span md-menu-align-target>{{ funderMembership.isAdmin ? "Undo" : "Make" }} administrator</span>
+                <span md-menu-align-target>{{ funderMembership.isAdmin ? "Undo" : "Make" }} Admin</span>
               </md-button>
             </md-menu-item>
 
             <md-menu-item ng-if="funderMembership.id != membership.id">
               <md-button ng-click="removeMembership(funderMembership)">
-                <span md-menu-align-target>Remove user</span>
+                <span md-menu-align-target>Remove User</span>
               </md-button>
             </md-menu-item>
           </md-menu-content>

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -128,13 +128,18 @@
   text-align: center;
 }
 
+.group-page__manage-funds-dialog :focus {
+  outline-color: transparent;
+  outline-style: none;
+}
+
 .group-page__manage-funds-dialog-header {
   padding-top: 10px !important;
   padding-bottom: 10px !important;
 }
 
 .group-page__manage-funds-dialog-header-avatar {
-  background: black;
+  background: rgba(0, 0, 0, 0.27);
   width: 60px;
   height: 60px;
   color: white;
@@ -153,8 +158,27 @@
   padding-top: 30px !important;
 }
 
+.group-page__manage-funds-option-container-disabled {
+  border-color: $cobudget-grey;
+  color: $cobudget-grey;
+  fill: $cobudget-grey;
+}
+
+.group-page__manage-funds-option-container-add {
+  border-color: $cobudget-green;
+  color: $cobudget-green;
+  fill: $cobudget-green;
+}
+
+.group-page__manage-funds-option-container-change {
+  border-color: $cobudget-pink;
+  color: $cobudget-pink;
+  fill: $cobudget-pink;
+}
+
 .group-page__manage-funds-option-icon-container {
-  border: 3px solid black;
+  border-width: 3px;
+  border-style: solid;
   border-radius: 50%;
   width: 24px;
   height: 24px;
@@ -200,7 +224,9 @@
 }
 
 .group-page__manage-funds-filler-text {
-  font-size: 14px;
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: normal;
 }
 
 .group-page__manage-funds-total-amount {
@@ -213,7 +239,6 @@
   font-weight: 500;
   letter-spacing: normal;
 }
-
 
 .group-page__manage-funds-dialog-cancel-btn {
   color: $cobudget-grey;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -126,6 +126,7 @@
 
 .group-page__manage-funds-dialog-header {
   padding-top: 10px !important;
+  padding-bottom: 10px !important;
 }
 
 .group-page__manage-funds-dialog-header-avatar {
@@ -143,4 +144,26 @@
   text-align: center;
   margin-top: 8px;
   color: $cobudget-dark-grey;
+}
+
+.group-page__manage-funds-options {
+  padding-top: 30px !important;
+}
+
+.group-page__manage-funds-option-icon-container {
+  border: 3px solid black;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  margin-bottom: 12px;
+}
+
+.group-page__manage-funds-change-icon > svg {
+  width: 16px;
+  position: relative;
+  left: 4px;
+}
+
+.group-page__manage-funds-option-label {
+  font-size: 15px;
 }

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -204,7 +204,6 @@
 .group-page__manage-funds-operator {
   position: relative;
   bottom: 2px;
-  margin: auto 3px;
 }
 
 .group-page__manage-funds-input-container {
@@ -213,7 +212,7 @@
 }
 
 .group-page__manage-funds-input {
-  width: 70px;
+  width: 80px;
   position: relative;
   font-weight: inherit;
   letter-spacing: inherit;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -235,13 +235,6 @@
   border-color: $cobudget-blue;
 }
 
-// duplicated because "when a browser doesn’t understand a selector, it invalidates the entire line of selectors (except IE 7)."
-// from https://css-tricks.com/snippets/css/style-placeholder-text/#comment-96772
-// .group-page__manage-funds-dialog ::-webkit-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-// .group-page__manage-funds-dialog :-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-// .group-page__manage-funds-dialog ::-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-// .group-page__manage-funds-dialog :-ms-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-
 .group-page__manage-funds-filler-text {
   font-size: 15px;
   font-weight: 400;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -194,6 +194,10 @@
   letter-spacing: inherit;
 }
 
+.group-page__manage-funds-calculation md-input-container:not(.md-input-invalid).md-input-focused .md-input {
+  border-color: $cobudget-blue;
+}
+
 .group-page__manage-funds-total-amount {
   color: $cobudget-green;
 }

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -174,6 +174,7 @@
   letter-spacing: 1px;
   text-align: center;
   color: $cobudget-dark-grey;
+  padding-bottom: 30px !important;
 }
 
 .group-page__manage-funds-operator {
@@ -207,4 +208,12 @@
   color: $cobudget-grey;
   font-weight: 500;
   letter-spacing: normal;
+}
+
+.group-page__manage-funds-dialog-cancel-btn {
+  color: $cobudget-grey;
+}
+
+.group-page__manage-funds-dialog-done-btn {
+  background: $cobudget-blue !important;
 }

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -224,8 +224,11 @@
   padding: 0 !important;
   font-weight: inherit;
   letter-spacing: inherit;
-  color: inherit;
   text-align: center;
+}
+
+.group-page__manage-funds-input-add {
+  color: $cobudget-green !important;
 }
 
 .group-page__manage-funds-dialog md-input-container:not(.md-input-invalid).md-input-focused .md-input {
@@ -243,10 +246,6 @@
   font-size: 15px;
   font-weight: 400;
   letter-spacing: normal;
-}
-
-.group-page__manage-funds-total-amount {
-  color: $cobudget-green;
 }
 
 .group-page__manage-funds-total-label {

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -167,3 +167,40 @@
 .group-page__manage-funds-option-label {
   font-size: 15px;
 }
+
+.group-page__manage-funds-calculation {
+  font-size: 22px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-align: center;
+  color: $cobudget-dark-grey;
+}
+
+.group-page__manage-funds-operator {
+  position: relative;
+  bottom: 2px;
+  margin: auto 3px;
+}
+
+.group-page__manage-funds-input-container {
+  display: inline-block;
+  padding-bottom: 20px !important;
+}
+
+.group-page__manage-funds-input {
+  width: 70px;
+  position: relative;
+  font-weight: inherit;
+  letter-spacing: inherit;
+}
+
+.group-page__manage-funds-total-amount {
+  color: $cobudget-green;
+}
+
+.group-page__manage-funds-total-label {
+  font-size: 14px;
+  color: $cobudget-grey;
+  font-weight: 500;
+  letter-spacing: normal;
+}

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -38,13 +38,27 @@
 }
 
 .group-page__funder-more-button {
-  width: 15px !important;  
+  width: 15px !important;
   margin-left: 14px !important;
   cursor: pointer;
 }
 
 .group-page__funder-more-button-icon {
-  width: 15px;  
+  width: 15px;
+}
+
+// funder more menu
+
+.group-page__manage-funds-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: $cobudget-dark-grey;
+  color: white;
+}
+
+.group-page__funder-more-menu-item-label {
+  margin-left: 12px;
 }
 
 // remove membership modal

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -208,7 +208,7 @@
 .group-page__manage-funds-operator {
   position: relative;
   bottom: 2px;
-  margin: auto 10px;
+  margin: auto 5px;
 }
 
 .group-page__manage-funds-input-container {

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -124,6 +124,10 @@
 
 // manage funds dialog
 
+.group-page__manage-funds-dialog {
+  text-align: center;
+}
+
 .group-page__manage-funds-dialog-header {
   padding-top: 10px !important;
   padding-bottom: 10px !important;
@@ -141,7 +145,6 @@
 .group-page__manage-funds-dialog-header-title {
   font-size: 18px;
   font-weight: 500;
-  text-align: center;
   margin-top: 8px;
   color: $cobudget-dark-grey;
 }
@@ -160,8 +163,6 @@
 
 .group-page__manage-funds-change-icon > svg {
   width: 16px;
-  position: relative;
-  left: 4px;
 }
 
 .group-page__manage-funds-option-label {
@@ -172,7 +173,6 @@
   font-size: 22px;
   font-weight: bold;
   letter-spacing: 1px;
-  text-align: center;
   color: $cobudget-dark-grey;
   padding-bottom: 30px !important;
 }
@@ -195,8 +195,12 @@
   letter-spacing: inherit;
 }
 
-.group-page__manage-funds-calculation md-input-container:not(.md-input-invalid).md-input-focused .md-input {
+.group-page__manage-funds-dialog md-input-container:not(.md-input-invalid).md-input-focused .md-input {
   border-color: $cobudget-blue;
+}
+
+.group-page__manage-funds-filler-text {
+  font-size: 14px;
 }
 
 .group-page__manage-funds-total-amount {
@@ -209,6 +213,7 @@
   font-weight: 500;
   letter-spacing: normal;
 }
+
 
 .group-page__manage-funds-dialog-cancel-btn {
   color: $cobudget-grey;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -194,38 +194,50 @@
 }
 
 .group-page__manage-funds-calculation {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: bold;
   letter-spacing: 1px;
   color: $cobudget-dark-grey;
-  padding-bottom: 30px !important;
+  overflow: auto;
+}
+
+.group-page__manage-funds-calculation-newline {
+  height: 20px;
 }
 
 .group-page__manage-funds-operator {
   position: relative;
   bottom: 2px;
+  margin: auto 10px;
 }
 
 .group-page__manage-funds-input-container {
   display: inline-block;
-  padding-bottom: 20px !important;
+  position: relative;
+  bottom: 1px;
+  padding: 0 !important;
 }
 
 .group-page__manage-funds-input {
   width: 80px;
-  position: relative;
+  display: inline-block !important;
+  padding: 0 !important;
   font-weight: inherit;
   letter-spacing: inherit;
+  color: inherit;
+  text-align: center;
 }
 
 .group-page__manage-funds-dialog md-input-container:not(.md-input-invalid).md-input-focused .md-input {
   border-color: $cobudget-blue;
 }
 
-.group-page__manage-funds-dialog ::-webkit-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-.group-page__manage-funds-dialog :-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-.group-page__manage-funds-dialog ::-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
-.group-page__manage-funds-dialog :-ms-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+// duplicated because "when a browser doesn’t understand a selector, it invalidates the entire line of selectors (except IE 7)."
+// from https://css-tricks.com/snippets/css/style-placeholder-text/#comment-96772
+// .group-page__manage-funds-dialog ::-webkit-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+// .group-page__manage-funds-dialog :-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+// .group-page__manage-funds-dialog ::-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+// .group-page__manage-funds-dialog :-ms-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
 
 .group-page__manage-funds-filler-text {
   font-size: 15px;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -227,8 +227,8 @@
   text-align: center;
 }
 
-.group-page__manage-funds-input-add {
-  color: $cobudget-green !important;
+.group-page__manage-funds-total-amount {
+  color: $cobudget-green;
 }
 
 .group-page__manage-funds-dialog md-input-container:not(.md-input-invalid).md-input-focused .md-input {

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -17,7 +17,7 @@
 
 .group-page__funder-name {
   @include truncatedText;
-  @include fontMedLarge;  
+  @include fontMedLarge;
 }
 
 .group-page__funder-balance {
@@ -55,10 +55,13 @@
   border-radius: 50%;
   background: $cobudget-dark-grey;
   color: white;
+  margin-right: 14px;
+  margin-left: 2px;
 }
 
-.group-page__funder-more-menu-item-label {
-  margin-left: 12px;
+.group-page__funder-more-menu-item-icon {
+  margin-right: 12px;
+  fill: $cobudget-dark-grey;
 }
 
 // remove membership modal

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -222,6 +222,11 @@
   border-color: $cobudget-blue;
 }
 
+.group-page__manage-funds-dialog ::-webkit-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+.group-page__manage-funds-dialog :-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+.group-page__manage-funds-dialog ::-moz-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+.group-page__manage-funds-dialog :-ms-input-placeholder { font-size: 15px; font-weight: normal; letter-spacing: normal; }
+
 .group-page__manage-funds-filler-text {
   font-size: 15px;
   font-weight: 400;

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -246,3 +246,8 @@
 .group-page__manage-funds-dialog-done-btn {
   background: $cobudget-blue !important;
 }
+
+.md-button[disabled], .md-button.md-raised[disabled] {
+  opacity: 0.20;
+  color: white !important;
+}

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -64,7 +64,7 @@
   fill: $cobudget-dark-grey;
 }
 
-// remove membership modal
+// remove membership dialog
 
 .group-page__remove-membership-dialog-header {
   text-align: center;
@@ -120,4 +120,27 @@
 .group-page__remove-membership-dialog-cancel-btn {
   color: $grey-on-white !important;
   background: transparent !important;
+}
+
+// manage funds dialog
+
+.group-page__manage-funds-dialog-header {
+  padding-top: 10px !important;
+}
+
+.group-page__manage-funds-dialog-header-avatar {
+  background: black;
+  width: 60px;
+  height: 60px;
+  color: white;
+  font-size: 35px;
+  border-radius: 50%;
+}
+
+.group-page__manage-funds-dialog-header-title {
+  font-size: 18px;
+  font-weight: 500;
+  text-align: center;
+  margin-top: 8px;
+  color: $cobudget-dark-grey;
 }

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -36,36 +36,39 @@
       </div>
     </div>
 
-    <div class="group-page__manage-funds-calculation">
-      <div ng-if="mode == 'add'">
-        <div>
-          <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
-          <span class="group-page__manage-funds-operator">+</span>
-          <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-            <input
-              class="group-page__manage-funds-input"
-              type="number"
-              step="any"
-              ng-model="formData.allocationAmount"
-              ng-change="normalizeAllocationAmount()"
-              ng-keypress="normalizeAllocationAmount()"
-            >
-          </md-input-container>
-        </div>
-        <div class="group-page__manage-funds-calculation-newline"></div>
-        <div>
-          <span class="group-page__manage-funds-operator">=</span>
-          <span class="group-page__manage-funds-total-amount">
-            {{ (formData.allocationAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 2}}
-          </span>
-          <span class="group-page__manage-funds-total-label">total</span>
-        </div>
+    <div class="group-page__manage-funds-calculation" ng-if="mode == 'add'">
+      <div>
+        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
+        <span class="group-page__manage-funds-operator">+</span>
+        <md-input-container class="group-page__manage-funds-input-container" md-no-float>
+          <input
+            class="group-page__manage-funds-input"
+            type="number"
+            step="any"
+            ng-model="formData.allocationAmount"
+            ng-change="normalizeAllocationAmount()"
+            ng-keypress="normalizeAllocationAmount()"
+          >
+        </md-input-container>
       </div>
+      <div class="group-page__manage-funds-calculation-newline"></div>
+      <div>
+        <span class="group-page__manage-funds-operator">=</span>
+        <span class="group-page__manage-funds-total-amount">
+          {{ (formData.allocationAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 2}}
+        </span>
+        <span class="group-page__manage-funds-total-label">total</span>
+      </div>
+    </div>
 
-      <div ng-if="mode == 'change'">
+    <div class="group-page__manage-funds-calculation" ng-if="mode == 'change'">
+      <div>
         <span class="group-page__manage-funds-filler-text">Change from</span>
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2}}</span>
         <span class="group-page__manage-funds-filler-text">to</span>
+      </div>
+      <div class="group-page__manage-funds-calculation-newline"></div>
+      <div>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
           <input
             class="group-page__manage-funds-input"
@@ -76,9 +79,11 @@
             ng-keypress="normalizeNewBalance()"
           >
         </md-input-container>
-        <span class="group-page__manage-funds-filler-text">total</span>
+        <span class="group-page__manage-funds-total-label">total</span>
       </div>
     </div>
+  </div>
+
   </md-dialog-content>
 
   <div class="md-actions" layout="row">

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -1,5 +1,5 @@
 <md-dialog class="group-page__manage-funds-dialog" aria-label="manage funds dialog">
-  <md-dialog-content class="sticky-container">
+  <md-dialog-content class="sticky-container group-page__manage-funds-dialog-content">
     <div class="group-page__manage-funds-dialog-header" layout="column" layout-align="space-between center">
       <div class="group-page__manage-funds-dialog-header-avatar" layout="column" layout-align="center center">
         <div>{{ managedMember.name[0] | uppercase }}</div>
@@ -38,23 +38,28 @@
 
     <div class="group-page__manage-funds-calculation">
       <div ng-if="mode == 'add'">
-        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
-        <span class="group-page__manage-funds-operator">+</span>
-        <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input placeholder="Amount"
-            class="group-page__manage-funds-input"
-            type="number"
-            step="any"
-            ng-model="formData.allocationAmount"
-            ng-change="normalizeAllocationAmount()"
-            ng-keypress="normalizeAllocationAmount()"
-          >
-        </md-input-container>
-        <span class="group-page__manage-funds-operator">=</span>
-        <span class="group-page__manage-funds-total-amount">
-          {{ (formData.allocationAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 2}}
-        </span>
-        <span class="group-page__manage-funds-total-label">total</span>
+        <div>
+          <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
+          <span class="group-page__manage-funds-operator">+</span>
+          <md-input-container class="group-page__manage-funds-input-container" md-no-float>
+            <input
+              class="group-page__manage-funds-input"
+              type="number"
+              step="any"
+              ng-model="formData.allocationAmount"
+              ng-change="normalizeAllocationAmount()"
+              ng-keypress="normalizeAllocationAmount()"
+            >
+          </md-input-container>
+        </div>
+        <div class="group-page__manage-funds-calculation-newline"></div>
+        <div>
+          <span class="group-page__manage-funds-operator">=</span>
+          <span class="group-page__manage-funds-total-amount">
+            {{ (formData.allocationAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 2}}
+          </span>
+          <span class="group-page__manage-funds-total-label">total</span>
+        </div>
       </div>
 
       <div ng-if="mode == 'change'">
@@ -62,7 +67,7 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2}}</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input placeholder="Amount"
+          <input
             class="group-page__manage-funds-input"
             type="number"
             step="any"

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -59,7 +59,7 @@
 
       <div ng-if="mode == 'change'">
         <span class="group-page__manage-funds-filler-text">Change from</span>
-        <span class="group-page__manage-funds-current-amount">$350</span>
+        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2}}</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
           <input aria-label="amount"

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -41,7 +41,7 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input
+          <input aria-label="amount"
             class="group-page__manage-funds-input"
             type="number"
             step="any"
@@ -70,7 +70,7 @@
       <div class="group-page__manage-funds-calculation-newline"></div>
       <div>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input
+          <input aria-label="amount"
             class="group-page__manage-funds-input"
             type="number"
             step="any"

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -46,7 +46,7 @@
   </md-dialog-content>
 
   <div class="md-actions" layout="row">
-    <md-button class="md-raised group-page__remove-membership-dialog-remove-btn" ng-click="proceed()">remove</md-button>
-    <md-button class="group-page__remove-membership-dialog-cancel-btn" ng-click="cancel()">cancel</md-button>
+    <md-button class="group-page__manage-funds-dialog-cancel-btn" ng-click="cancel()">cancel</md-button>
+  <md-button class="md-raised md-primary group-page__manage-funds-dialog-done-btn" ng-click="proceed()">done</md-button>
   </div>
 </md-dialog>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -78,6 +78,6 @@
 
   <div class="md-actions" layout="row">
     <md-button class="group-page__manage-funds-dialog-cancel-btn" ng-click="cancel()">cancel</md-button>
-    <md-button class="md-raised md-primary group-page__manage-funds-dialog-done-btn" ng-disabled="!isValidForm()" ng-click="done()">done</md-button>
+    <md-button class="md-raised md-primary group-page__manage-funds-dialog-done-btn" ng-disabled="!isValidForm()" ng-click="createAllocation()">done</md-button>
   </div>
 </md-dialog>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -41,7 +41,7 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount"
+          <input placeholder="Amount"
             class="group-page__manage-funds-input"
             type="number"
             step="any"
@@ -62,7 +62,7 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2}}</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount"
+          <input placeholder="Amount"
             class="group-page__manage-funds-input"
             type="number"
             step="any"

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -32,7 +32,15 @@
       </div>
     </div>
 
-    <div class="group-page__manage-funds-input">
+    <div class="group-page__manage-funds-calculation">
+      <span class="group-page__manage-funds-current-amount">$350</span>
+      <span class="group-page__manage-funds-operator">+</span>
+      <md-input-container class="group-page__manage-funds-input-container" md-no-float>
+        <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
+      </md-input-container>
+      <span class="group-page__manage-funds-operator">=</span>
+      <span class="group-page__manage-funds-total-amount">$350</span>
+      <span class="group-page__manage-funds-total-label">total</span>
     </div>
 
   </md-dialog-content>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -13,20 +13,24 @@
     <md-divider></md-divider>
 
     <div class="group-page__manage-funds-options" layout="row" layout-align="space-around center">
-      <div class="group-page__manage-funds-option-container" layout="column" layout-align="space-around center">
+      <div ng-class="mode == 'add' ? 'group-page__manage-funds-option-container-add' : 'group-page__manage-funds-option-container-disabled'"
+        layout="column"
+        layout-align="space-around center"
+        ng-click="setMode('add')"
+      >
         <div class="group-page__manage-funds-option-icon-container">
-          <ng-md-icon icon="add"
-            class="group-page__manage-funds-option-icon"
-          ></ng-md-icon>
+          <ng-md-icon icon="add" class="group-page__manage-funds-option-icon"></ng-md-icon>
         </div>
         <div class="group-page__manage-funds-option-label">Add</div>
       </div>
 
-      <div class="group-page__manage-funds-option-container" layout="column" layout-align="space-around center">
+      <div ng-class="mode == 'change' ? 'group-page__manage-funds-option-container-change' : 'group-page__manage-funds-option-container-disabled'"
+        layout="column"
+        layout-align="space-around center"
+        ng-click="setMode('change')"
+      >
         <div class="group-page__manage-funds-option-icon-container">
-          <ng-md-icon icon="edit"
-            class="group-page__manage-funds-option-icon group-page__manage-funds-change-icon"
-          ></ng-md-icon>
+          <ng-md-icon icon="edit" class="group-page__manage-funds-option-icon group-page__manage-funds-change-icon"></ng-md-icon>
         </div>
         <div class="group-page__manage-funds-option-label">Change</div>
       </div>
@@ -54,7 +58,6 @@
         <span class="group-page__manage-funds-filler-text">total</span>
       </div>
     </div>
-
   </md-dialog-content>
 
   <div class="md-actions" layout="row">

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -38,13 +38,15 @@
 
     <div class="group-page__manage-funds-calculation">
       <div ng-if="mode == 'add'">
-        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 0 }}</span>
+        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" ng-model="fundingAmount">
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" ng-model="formData.allocationAmount" ng-change="normalizeAllocationAmount()" ng-keypress="normalizeAllocationAmount()">
         </md-input-container>
         <span class="group-page__manage-funds-operator">=</span>
-        <span class="group-page__manage-funds-total-amount">{{ (fundingAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 0}}</span>
+        <span class="group-page__manage-funds-total-amount">
+          {{ (formData.allocationAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 2}}
+        </span>
         <span class="group-page__manage-funds-total-label">total</span>
       </div>
 
@@ -53,7 +55,7 @@
         <span class="group-page__manage-funds-current-amount">$350</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="fundingAmount">
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="formData.something">
         </md-input-container>
         <span class="group-page__manage-funds-filler-text">total</span>
       </div>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -41,7 +41,7 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount"
+          <input placeholder="XX.XX"
             class="group-page__manage-funds-input group-page__manage-funds-input-add"
             type="number"
             step="any"
@@ -70,7 +70,7 @@
       <div class="group-page__manage-funds-calculation-newline"></div>
       <div>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount"
+          <input placeholder="XX.XX"
             class="group-page__manage-funds-input"
             type="number"
             step="any"

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -2,7 +2,7 @@
   <md-dialog-content class="sticky-container">
     <div class="group-page__manage-funds-dialog-header" layout="column" layout-align="space-between center">
       <div class="group-page__manage-funds-dialog-header-avatar" layout="column" layout-align="center center">
-        <div>A</div>
+        <div>{{ managedMember.name[0] | uppercase }}</div>
       </div>
 
       <div class="group-page__manage-funds-dialog-header-title">

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="manage funds dialog">
+<md-dialog class="group-page__manage-funds-dialog" aria-label="manage funds dialog">
   <md-dialog-content class="sticky-container">
     <div class="group-page__manage-funds-dialog-header" layout="column" layout-align="space-between center">
       <div class="group-page__manage-funds-dialog-header-avatar" layout="column" layout-align="center center">
@@ -33,14 +33,26 @@
     </div>
 
     <div class="group-page__manage-funds-calculation">
-      <span class="group-page__manage-funds-current-amount">$350</span>
-      <span class="group-page__manage-funds-operator">+</span>
-      <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-        <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
-      </md-input-container>
-      <span class="group-page__manage-funds-operator">=</span>
-      <span class="group-page__manage-funds-total-amount">$350</span>
-      <span class="group-page__manage-funds-total-label">total</span>
+      <div ng-if="mode == 'add'">
+        <span class="group-page__manage-funds-current-amount">$350</span>
+        <span class="group-page__manage-funds-operator">+</span>
+        <md-input-container class="group-page__manage-funds-input-container" md-no-float>
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
+        </md-input-container>
+        <span class="group-page__manage-funds-operator">=</span>
+        <span class="group-page__manage-funds-total-amount">$350</span>
+        <span class="group-page__manage-funds-total-label">total</span>
+      </div>
+
+      <div ng-if="mode == 'change'">
+        <span class="group-page__manage-funds-filler-text">Change from</span>
+        <span class="group-page__manage-funds-current-amount">$350</span>
+        <span class="group-page__manage-funds-filler-text">to</span>
+        <md-input-container class="group-page__manage-funds-input-container" md-no-float>
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
+        </md-input-container>
+        <span class="group-page__manage-funds-filler-text">total</span>
+      </div>
     </div>
 
   </md-dialog-content>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -6,7 +6,7 @@
       </div>
 
       <div class="group-page__manage-funds-dialog-header-title">
-        Manage Alanna Krause's funds
+        Manage {{ managedMember.name }}'s funds
       </div>
     </div>
 
@@ -38,13 +38,13 @@
 
     <div class="group-page__manage-funds-calculation">
       <div ng-if="mode == 'add'">
-        <span class="group-page__manage-funds-current-amount">$350</span>
+        <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 0 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" ng-model="fundingAmount">
         </md-input-container>
         <span class="group-page__manage-funds-operator">=</span>
-        <span class="group-page__manage-funds-total-amount">$350</span>
+        <span class="group-page__manage-funds-total-amount">{{ (fundingAmount || 0) + managedMembership.balance() | currency : group.currencySymbol : 0}}</span>
         <span class="group-page__manage-funds-total-label">total</span>
       </div>
 
@@ -53,7 +53,7 @@
         <span class="group-page__manage-funds-current-amount">$350</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="amount">
+          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="fundingAmount">
         </md-input-container>
         <span class="group-page__manage-funds-filler-text">total</span>
       </div>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -41,7 +41,14 @@
         <span class="group-page__manage-funds-current-amount">{{ managedMembership.balance() | currency : group.currencySymbol : 2 }}</span>
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" ng-model="formData.allocationAmount" ng-change="normalizeAllocationAmount()" ng-keypress="normalizeAllocationAmount()">
+          <input aria-label="amount"
+            class="group-page__manage-funds-input"
+            type="number"
+            step="any"
+            ng-model="formData.allocationAmount"
+            ng-change="normalizeAllocationAmount()"
+            ng-keypress="normalizeAllocationAmount()"
+          >
         </md-input-container>
         <span class="group-page__manage-funds-operator">=</span>
         <span class="group-page__manage-funds-total-amount">
@@ -55,7 +62,14 @@
         <span class="group-page__manage-funds-current-amount">$350</span>
         <span class="group-page__manage-funds-filler-text">to</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
-          <input aria-label="amount" class="group-page__manage-funds-input" type="number" step="any" min="0" pattern="[0-9]*" ng-model="formData.something">
+          <input aria-label="amount"
+            class="group-page__manage-funds-input"
+            type="number"
+            step="any"
+            ng-model="formData.newBalance"
+            ng-change="normalizeNewBalance()"
+            ng-keypress="normalizeNewBalance()"
+          >
         </md-input-container>
         <span class="group-page__manage-funds-filler-text">total</span>
       </div>
@@ -64,6 +78,6 @@
 
   <div class="md-actions" layout="row">
     <md-button class="group-page__manage-funds-dialog-cancel-btn" ng-click="cancel()">cancel</md-button>
-  <md-button class="md-raised md-primary group-page__manage-funds-dialog-done-btn" ng-click="proceed()">done</md-button>
+    <md-button class="md-raised md-primary group-page__manage-funds-dialog-done-btn" ng-disabled="!isValidForm()" ng-click="done()">done</md-button>
   </div>
 </md-dialog>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -1,0 +1,21 @@
+<md-dialog aria-label="manage funds dialog">
+  <md-dialog-content class="sticky-container">
+    <div class="group-page__manage-funds-dialog-header" layout="column" layout-align="space-between center">
+      <div class="group-page__manage-funds-dialog-header-avatar" layout="column" layout-align="center center">
+        <div>A</div>
+      </div>
+
+      <div class="group-page__manage-funds-dialog-header-title">
+        Manage Alanna Krause's funds
+      </div>
+    </div>
+
+    <md-divider></md-divider>
+
+  </md-dialog-content>
+
+  <div class="md-actions" layout="row">
+    <md-button class="md-raised group-page__remove-membership-dialog-remove-btn" ng-click="proceed()">remove</md-button>
+    <md-button class="group-page__remove-membership-dialog-cancel-btn" ng-click="cancel()">cancel</md-button>
+  </div>
+</md-dialog>

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -82,7 +82,6 @@
         <span class="group-page__manage-funds-total-label">total</span>
       </div>
     </div>
-  </div>
 
   </md-dialog-content>
 

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -12,6 +12,29 @@
 
     <md-divider></md-divider>
 
+    <div class="group-page__manage-funds-options" layout="row" layout-align="space-around center">
+      <div class="group-page__manage-funds-option-container" layout="column" layout-align="space-around center">
+        <div class="group-page__manage-funds-option-icon-container">
+          <ng-md-icon icon="add"
+            class="group-page__manage-funds-option-icon"
+          ></ng-md-icon>
+        </div>
+        <div class="group-page__manage-funds-option-label">Add</div>
+      </div>
+
+      <div class="group-page__manage-funds-option-container" layout="column" layout-align="space-around center">
+        <div class="group-page__manage-funds-option-icon-container">
+          <ng-md-icon icon="edit"
+            class="group-page__manage-funds-option-icon group-page__manage-funds-change-icon"
+          ></ng-md-icon>
+        </div>
+        <div class="group-page__manage-funds-option-label">Change</div>
+      </div>
+    </div>
+
+    <div class="group-page__manage-funds-input">
+    </div>
+
   </md-dialog-content>
 
   <div class="md-actions" layout="row">

--- a/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
+++ b/app/directives/group-page-funders/manage-funds-dialog.tmpl.html
@@ -42,7 +42,7 @@
         <span class="group-page__manage-funds-operator">+</span>
         <md-input-container class="group-page__manage-funds-input-container" md-no-float>
           <input aria-label="amount"
-            class="group-page__manage-funds-input"
+            class="group-page__manage-funds-input group-page__manage-funds-input-add"
             type="number"
             step="any"
             ng-model="formData.allocationAmount"

--- a/app/directives/group-page-toolbar/group-page-toolbar.html
+++ b/app/directives/group-page-toolbar/group-page-toolbar.html
@@ -34,40 +34,40 @@
 
         <md-menu-item>
           <md-button aria-label="Give Feedback" ng-click="openFeedbackForm()">
-          <div layout="row" layout-align="start center">
-            <ng-md-icon icon="live_help"
-              class="group-page__toolbar-menu-icon"
-              layout="column"
-              layout-align="center center"
-            ></ng-md-icon>
-            <span md-menu-align-target>Give Feedback</span>
-          </div>
+            <div layout="row" layout-align="start center">
+              <ng-md-icon icon="live_help"
+                class="group-page__toolbar-menu-icon"
+                layout="column"
+                layout-align="center center"
+              ></ng-md-icon>
+              <span md-menu-align-target>Give Feedback</span>
+            </div>
           </md-button>
         </md-menu-item>
 
         <md-menu-item ng-if="membership.isAdmin">
           <md-button aria-label="Admin Panel" ng-click="openAdminPanel()">
-          <div layout="row" layout-align="start center">
-            <ng-md-icon icon="local_pizza"
-              class="group-page__toolbar-menu-icon"
-              layout="column"
-              layout-align="center center"
-            ></ng-md-icon>
-            <span md-menu-align-target>Admin Panel</span>
-          </div>
+            <div layout="row" layout-align="start center">
+              <ng-md-icon icon="local_pizza"
+                class="group-page__toolbar-menu-icon"
+                layout="column"
+                layout-align="center center"
+              ></ng-md-icon>
+              <span md-menu-align-target>Admin Panel</span>
+            </div>
           </md-button>
         </md-menu-item>
 
         <md-menu-item>
           <md-button aria-label="Log Out" ng-click="signOut()">
-          <div layout="row" layout-align="start center">
-            <ng-md-icon icon="exit_to_app"
-              class="group-page__toolbar-menu-icon"
-              layout="column"
-              layout-align="center center"
-            ></ng-md-icon>
-            <span md-menu-align-target>Log Out</span>
-          </div>
+            <div layout="row" layout-align="start center">
+              <ng-md-icon icon="exit_to_app"
+                class="group-page__toolbar-menu-icon"
+                layout="column"
+                layout-align="center center"
+              ></ng-md-icon>
+              <span md-menu-align-target>Log Out</span>
+            </div>
           </md-button>
         </md-menu-item>
       </md-menu-content>

--- a/app/index.scss
+++ b/app/index.scss
@@ -33,4 +33,4 @@
 @import './directives/error-page/error-page.scss';
 @import './directives/loading-page/loading-page.scss';
 
-@import './components/ng-material-customs.scss';
+@import './components/globals.scss';

--- a/app/models/allocation-model.coffee
+++ b/app/models/allocation-model.coffee
@@ -5,4 +5,5 @@ global.cobudgetApp.factory 'AllocationModel', (BaseModel) ->
   class AllocationModel extends BaseModel
     @singular: 'allocation'
     @plural: 'allocations'
-    @indices: ['groupId']
+    @indices: ['groupId', 'userId']
+    @serializableAttributes: ['groupId', 'userId', 'amount']

--- a/app/models/allocation-model.coffee
+++ b/app/models/allocation-model.coffee
@@ -7,3 +7,7 @@ global.cobudgetApp.factory 'AllocationModel', (BaseModel) ->
     @plural: 'allocations'
     @indices: ['groupId', 'userId']
     @serializableAttributes: ['groupId', 'userId', 'amount']
+
+    relationships: ->
+      @belongsTo 'group'
+      @belongsTo 'user'

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -17,4 +17,3 @@ global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
 
     archive: ->
       @remote.postMember(@id, 'archive')
-      


### PR DESCRIPTION
@mixmix 

trello card: https://trello.com/c/jYGMIZwi/12-3-admin-can-change-user-funds

demonstrative gif: http://g.recordit.co/TLHI4KV3ye.gif

in this PR:
- added `manage funds` button to the funder menu dropdown
- added icons for existing buttons on the funder menu
- `manage funds` button's icon adapts to the group's currency symbol
- clicking on `manage funds` for a member, opens up a `manage funds dialog` with a form
- clicking `cancel` on the dialog closes the dialog
- clicking on the `add` and `change` buttons on the dialog changes the format of the form 
- form is designed so that admin cannot put down an amount that will bring a member's balance below 0
- form's submit button is disabled until a valid number is entered
- on form submission, allocation is created, and the UI is asynchronously updated

partner API PR: https://github.com/cobudget/cobudget-api/pull/97