### PR TITLE
Hotfix/add author name to serializers

### DIFF
--- a/app/directives/bucket-page-activity-card/bucket-page-activity-card.html
+++ b/app/directives/bucket-page-activity-card/bucket-page-activity-card.html
@@ -22,7 +22,7 @@
     <md-list class="bucket-page__comment-list">
       <md-list-item class="bucket-page__comment" ng-repeat="comment in bucket.comments()" layout="column" layout-align="center start">
         <md-divider></md-divider>
-        <div class="bucket-page__comment-author-name">{{ comment.authorName() }}</div>
+        <div class="bucket-page__comment-author-name">{{ comment.authorName }}</div>
         <div class="bucket-page__comment-body" marked="comment.body"></div>
       </md-list-item>
     </md-list>

--- a/app/directives/bucket-page-header-card/bucket-page-header-card.html
+++ b/app/directives/bucket-page-header-card/bucket-page-header-card.html
@@ -1,7 +1,7 @@
 <md-card class="bucket-page__header-card">
   <md-card-content class="bucket-page__meta">
     <div class="bucket-page__title">{{ bucket.name }}</div>
-    <div class="bucket-page__author">created by {{ bucket.authorName() }} {{ bucket.createdAt | timeFromNowInWords }} ago</div>
+    <div class="bucket-page__author">created by {{ bucket.authorName }} {{ bucket.createdAt | timeFromNowInWords }} ago</div>
   </md-card-content>
 
   <md-card-content class="bucket-page__description">

--- a/app/directives/group-page-buckets/group-page-buckets.html
+++ b/app/directives/group-page-buckets/group-page-buckets.html
@@ -37,8 +37,8 @@
     <md-list-item ng-repeat="draftBucket in group.draftBuckets()" ng-click="showBucket(draftBucket.id)">
       <div layout="column" flex class="group-page__draft-container">
         <span class="group-page__draft-title">{{ draftBucket.name }}</span>
-        <span class="group-page__draft-author">created by {{ draftBucket.authorName() }} {{ draftBucket.createdAt | timeFromNowInWords }} ago</span>
-        
+        <span class="group-page__draft-author">created by {{ draftBucket.authorName }} {{ draftBucket.createdAt | timeFromNowInWords }} ago</span>
+
         <div class="group-page__comment-count-container">
           <ng-md-icon 
             icon="messenger" 
@@ -66,7 +66,7 @@
     <md-list-item ng-repeat="fundedBucket in group.fundedBuckets()" ng-click="showBucket(fundedBucket.id)">
       <div layout="column" flex class="group-page__funded-bucket-container">
         <span class="group-page__funded-bucket-title">{{ fundedBucket.name }}</span>
-        <span class="group-page__funded-bucket-author">created by {{ fundedBucket.authorName() }} {{ fundedBucket.createdAt | timeFromNowInWords }} ago</span>
+        <span class="group-page__funded-bucket-author">created by {{ fundedBucket.authorName }} {{ fundedBucket.createdAt | timeFromNowInWords }} ago</span>
       </div>
     </md-list-item>
   </md-list>

--- a/app/models/bucket-model.coffee
+++ b/app/models/bucket-model.coffee
@@ -41,9 +41,3 @@ global.cobudgetApp.factory 'BucketModel', (BaseModel) ->
 
     percentContributedByUser: (user) ->
       @amountContributedByUser(user) / @target * 100
-
-    authorName: ->
-      if @author().isMemberOf(@group())
-        @author().name
-      else
-        "[removed user]"

--- a/app/models/comment-model.coffee
+++ b/app/models/comment-model.coffee
@@ -11,9 +11,3 @@ global.cobudgetApp.factory 'CommentModel', (BaseModel) ->
     relationships: ->
       @belongsTo 'author', from: 'users', by: 'userId'
       @belongsTo 'bucket'
-
-    authorName: ->
-      if @author().isMemberOf(@bucket().group())
-        @author().name
-      else
-        "[removed user]"


### PR DESCRIPTION
as described in this [trello card](https://trello.com/c/G8CLbBRh/383-visiting-bucket-page-from-email-link-renders-all-comment-author-s-names-as-removed-user-except-current-user), when visiting the bucket page from an external link (having not visited the group-page first), the author names for the bucket and for its comments display `[removed user]`. 

this happens because, the `authorName` methods for the `CommentModel` and `BucketModel` look like this:

```coffeescript
authorName: ->		
  if @author().isMemberOf(@group())		
    @author().name		
  else		
    "[removed user]"
```

where `UserModel`'s `isMemberOf` method looks like:

```coffeescript
isMemberOf: (group) ->
  _.find @memberships(), (membership) ->
    membership.groupId == group.id 
```

when visiting the bucket page directly, the bucket's users, and the bucket's comments' users are fetched from the API -- but, not the memberships for these users. so the `UserModel`s `isMemberOf` method returns `falsey`, causing `authorName` to return `"[removed user]".

to work around this, i've included the author's name in the API's `CommentSerializer` and `BucketSerializer` as shown in this partner PR: https://github.com/cobudget/cobudget-api/pull/98

this workaround works, but also further convinces me that it would be a good idea to bind comments and buckets to **memberships** instead of **users**, since comments and buckets **only exist within the scope of a group**