### PR TITLE
Feature/invitation status and reinvite user

### DIFF
--- a/app/components/globals.scss
+++ b/app/components/globals.scss
@@ -19,3 +19,7 @@ md-toast > button.md-button {
 input[type=number] {
   -moz-appearance: textfield !important;
 }
+
+md-dialog-content {
+  word-wrap: break-word;
+}

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -5,20 +5,23 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
     restrict: 'E'
     template: require('./group-page-funders.html')
     replace: true
-    controller: (Dialog, LoadBar, Records, $scope, $window) ->
+    controller: (Dialog, LoadBar, Records, $scope, Toast, $window) ->
 
       $scope.toggleMemberAdmin = (membership) ->
         membership.isAdmin = !membership.isAdmin
         membership.save()
 
       $scope.inviteAgain = (membership) ->
-        alert('i was called')
-        Records.memberships.reinvite(membership)
-          .then (res) ->
-            console.log('res: ', res)
-            alert('it work')
-          .catch ->
-            alert('it not work')
+        member = membership.member()
+        Dialog.confirm({
+          content: "This will send another invitation to #{member.name} at #{member.email}",
+          ok: 'send'
+        }).then ->
+          Records.memberships.reinvite(membership)
+            .then ->
+              Toast.show('Invitation sent!')
+            .catch ->
+              Dialog.alert({title: 'Error!'})
 
       $scope.removeMembership = (membership) ->
         Dialog.custom

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -5,11 +5,20 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
     restrict: 'E'
     template: require('./group-page-funders.html')
     replace: true
-    controller: (Dialog, LoadBar, $scope, $window) ->
+    controller: (Dialog, LoadBar, Records, $scope, $window) ->
 
       $scope.toggleMemberAdmin = (membership) ->
         membership.isAdmin = !membership.isAdmin
         membership.save()
+
+      $scope.inviteAgain = (membership) ->
+        alert('i was called')
+        Records.memberships.reinvite(membership)
+          .then (res) ->
+            console.log('res: ', res)
+            alert('it work')
+          .catch ->
+            alert('it not work')
 
       $scope.removeMembership = (membership) ->
         Dialog.custom

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -12,16 +12,20 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
         membership.save()
 
       $scope.inviteAgain = (membership) ->
-        member = membership.member()
-        Dialog.confirm({
-          content: "This will send another invitation to #{member.name} at #{member.email}",
-          ok: 'send'
-        }).then ->
-          Records.memberships.reinvite(membership)
-            .then ->
-              Toast.show('Invitation sent!')
-            .catch ->
-              Dialog.alert({title: 'Error!'})
+        Dialog.custom
+          template: require('./reinvite-user-dialog.tmpl.html')
+          scope: $scope
+          controller: (Dialog, $mdDialog, Records, $scope, Toast) ->
+            $scope.member = membership.member()
+            $scope.cancel = ->
+              $mdDialog.cancel()
+            $scope.proceed = ->
+              Records.memberships.reinvite(membership)
+                .then ->
+                  $scope.cancel()
+                  Toast.show('Invitation sent!')
+                .catch ->
+                  Dialog.alert({title: 'Error!'})
 
       $scope.removeMembership = (membership) ->
         Dialog.custom

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -8,7 +8,11 @@
 
         <div layout="column" layout-align="center start" flex>
           <span class="group-page__funder-name">{{ funderMembership.member().name }}</span>
-          <span class="group-page__funder-admin-label" ng-if="funderMembership.isAdmin">(admin)</span>
+          <span class="group-page__funder-admin-label" ng-if="!funderMembership.isPending() && funderMembership.isAdmin">(admin)</span>
+          <span class="group-page__funder-admin-label" ng-if="funderMembership.isPending()">
+            <ng-md-icon icon="mail" size="17" class="group-page__funder-invited-icon"></ng-md-icon>
+            <span class="group-page__funder-invited-label">Invited</span>
+          </span>
         </div>
 
         <div layout="column" layout-align="center end" class="group-page__funder-balance-container">

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -50,6 +50,20 @@
               </md-button>
             </md-menu-item>
 
+            <md-menu-item>
+              <md-button ng-click="toggleMemberAdmin(funderMembership)">
+                <div layout="row" layout-align="start center">
+                  <ng-md-icon
+                    icon="mail"
+                    layout="column"
+                    layout-align="center center"
+                    class="group-page__funder-more-menu-item-icon"
+                  ></ng-md-icon>
+                  <span md-menu-align-target class="group-page__funder-more-menu-item-label">Invite Again</span>
+                </div>
+              </md-button>
+            </md-menu-item>
+
             <md-menu-item ng-if="funderMembership.id != membership.id">
               <md-button ng-click="removeMembership(funderMembership)">
                 <div layout="row" layout-align="start center">

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -56,7 +56,7 @@
             </md-menu-item>
 
             <md-menu-item>
-              <md-button ng-click="toggleMemberAdmin(funderMembership)">
+              <md-button ng-click="inviteAgain(funderMembership)">
                 <div layout="row" layout-align="start center">
                   <ng-md-icon
                     icon="mail"

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -1,16 +1,17 @@
 <div class="group-page__funders-content">
   <md-list class="group-page__funders">
     <md-list-item ng-repeat="funderMembership in group.memberships()">
-      <div layout="row" flex class="group-page__funder-container">
-        <div class="group-page__funder-name-container" layout="row" layout-align="start center" flex>
-          <div class="group-page__funder-avatar" layout="column" layout-align="center center">
-            <div>{{ funderMembership.member().name[0] | uppercase }}</div>
-          </div>
+      <div layout="row" layout-align="start center" flex class="group-page__funder-container">
+        <div class="group-page__funder-avatar" layout="column" layout-align="center center">
+          <div>{{ funderMembership.member().name[0] | uppercase }}</div>
+        </div>
+
+        <div layout="column" layout-align="center start" flex>
           <span class="group-page__funder-name">{{ funderMembership.member().name }}</span>
           <span class="group-page__funder-admin-label" ng-if="funderMembership.isAdmin">(admin)</span>
         </div>
 
-        <div layout="column" layout-align="center end" flex="20">
+        <div layout="column" layout-align="center end" class="group-page__funder-balance-container">
           <span class="group-page__funder-balance">{{ funderMembership.balance() | currency : group.currencySymbol : 0 }}</span>
         </div>
 

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -15,7 +15,7 @@
   border-radius: 50%;
   background: rgba(0,0,0,0.27);
   color: white;
-  font-size: 16px;
+  font-size: 20px;
   margin-right: 10px;
 }
 

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -279,3 +279,8 @@
   opacity: 0.20;
   color: white !important;
 }
+
+// reinvite user dialog
+.group-page__reinvite-user-dialog-content {
+  padding: 30px !important;
+}

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -5,9 +5,13 @@
   padding-right: 16px;
 }
 
+.group-page__funder-container {
+  margin-bottom: 10px;
+}
+
 .group-page__funder-avatar {
-  width: 25px;
-  height: 25px;
+  width: 45px;
+  height: 45px;
   border-radius: 50%;
   background: rgba(0,0,0,0.27);
   color: white;
@@ -16,21 +20,25 @@
 }
 
 .group-page__funder-name {
+  width: 100%;
   @include truncatedText;
-  @include fontMedLarge;
+  @include fontMedium;
+}
+
+.group-page__funder-balance-container {
+  margin-left: 15px;
 }
 
 .group-page__funder-balance {
-  @include fontLarge;
+  font-size: 19px;
   color: $cobudget-green;
+  font-weight: 500;
 }
 
 .group-page__funder-admin-label {
+  margin-top: 3px;
   color: $grey-on-white;
-  font-size: 12px;
-  margin-left: 5px;
-  top: 1px;
-  position: relative;
+  font-size: 11px;
 }
 
 .group-page__funder-more-menu {
@@ -45,6 +53,7 @@
 
 .group-page__funder-more-button-icon {
   width: 15px;
+  fill: rgba(0,0,0,0.40);
 }
 
 // funder more menu

--- a/app/directives/group-page-funders/group-page-funders.scss
+++ b/app/directives/group-page-funders/group-page-funders.scss
@@ -25,6 +25,16 @@
   @include fontMedium;
 }
 
+.group-page__funder-invited-icon {
+  fill: rgba(0,0,0,0.5);
+}
+
+.group-page__funder-invited-label {
+  position: relative;
+  bottom: 4px;
+  margin-left: 1px;
+}
+
 .group-page__funder-balance-container {
   margin-left: 15px;
 }

--- a/app/directives/group-page-funders/reinvite-user-dialog.tmpl.html
+++ b/app/directives/group-page-funders/reinvite-user-dialog.tmpl.html
@@ -1,0 +1,9 @@
+<md-dialog aria-label="reinvite user dialog">
+  <md-dialog-content class="sticky-container group-page__reinvite-user-dialog-content">
+    This will send another invitation to <b>{{member.name}}</b> at <b>{{member.email}}</b>
+  </md-dialog-content>
+  <div class="md-actions" layout="row">
+    <md-button ng-click="cancel()">cancel</md-button>
+    <md-button ng-click="proceed()">send</md-button>
+  </div>
+</md-dialog>

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -16,7 +16,7 @@ global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
       parseFloat(@totalAllocations) - parseFloat(@totalContributions)
 
     isPending: ->
-      @member().confirmationToken != null
+      @member().isPendingConfirmation
 
     archive: ->
       @remote.postMember(@id, 'archive')

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -15,5 +15,8 @@ global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
     balance: ->
       parseFloat(@totalAllocations) - parseFloat(@totalContributions)
 
+    isPending: ->
+      @member().confirmationToken != null
+
     archive: ->
       @remote.postMember(@id, 'archive')

--- a/app/records-interfaces/membership-records-interface.coffee
+++ b/app/records-interfaces/membership-records-interface.coffee
@@ -1,16 +1,22 @@
-null 
+null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'MembershipRecordsInterface', (config, BaseRecordsInterface, MembershipModel) -> 
+global.cobudgetApp.factory 'MembershipRecordsInterface', (config, BaseRecordsInterface, MembershipModel) ->
   class MembershipRecordsInterface extends BaseRecordsInterface
     model: MembershipModel
+
     constructor: (recordStore) ->
       @baseConstructor recordStore
       @remote.apiPrefix = config.apiPrefix
+
     fetchMyMemberships: ->
       @fetch
         path: 'my_memberships'
+
     fetchByGroupId: (groupId) ->
       @fetch
         params:
           group_id: groupId
+
+    reinvite: (membership) ->
+      @remote.postMember(membership.id, 'reinvite')

--- a/app/services/dialog.coffee
+++ b/app/services/dialog.coffee
@@ -13,9 +13,9 @@ global.cobudgetApp.factory 'Dialog', ($mdDialog) ->
 
     confirm: (args = {}) ->
       confirm = $mdDialog.confirm
-        title: args.title 
+        title: args.title
         content: args.content
-        ok: args.confirm || 'ok'
+        ok: args.ok || 'ok'
         cancel: args.cancel || 'cancel'
       $mdDialog.show(confirm)
 


### PR DESCRIPTION
[demonstrative gif](http://g.recordit.co/mzxjwYcDTI.gif)

[partner API PR](https://github.com/cobudget/cobudget-api/pull/99)

[trello card](https://trello.com/c/RPq6FQcQ/267-2-invitation-status-and-reinvite-user-2)

---
### in this PR:

- restyled funders page
  - larger avatars
  - smaller font size for funder name
  - larger font size for funder balance
  - reduced opacity of funder's more button
- added 'Invite Again' button to funder's more button dropdown menu
- when 'Invite Again' button is clicked, triggers a confirmation dialog
- on confirmation, the user is assigned a new confirmation_token, and receive another invite email, and Toast appears at bottom of the screen saying 'Invitation Sent!'
- Funders who still have a confirmation_token (indicating that they haven't set up their cobudget account yet) have a little 'invited' label and icon under their name on the funders page. 

