### PR TITLE
on login success, if user is pending confirmation, remove confirmation_token

### DIFF
--- a/app/boot.coffee
+++ b/app/boot.coffee
@@ -21,13 +21,14 @@ global.cobudgetApp.run ($auth, CurrentUser, Dialog, LoadBar, $location, $q, Reco
           $location.path('/')
           Dialog.alert(title: 'error!', content: 'invalid credentials!')
           LoadBar.stop()
-          
       if data.groups && _.every(data.groups, {'initialized': true})
         groupId = data.groups[0].id
         $location.path("/groups/#{groupId}")
         Toast.show('Welcome to Cobudget!')
         if CurrentUser().utcOffset != moment().utcOffset()
           Records.users.updateProfile(utc_offset: moment().utcOffset())
+        if CurrentUser().isPendingConfirmation
+          Records.users.updateProfile(confirmationToken: null)
 
   $rootScope.$on '$stateChangeError', (e, toState, toParams, fromState, fromParams, error) ->
     console.log('$stateChangeError signal fired!')

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -10,7 +10,8 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
       'email',
       'subscribedToPersonalActivity',
       'subscribedToDailyDigest',
-      'subscribedToParticipantActivity'
+      'subscribedToParticipantActivity',
+      'confirmationToken'
     ]
 
     relationships: ->
@@ -26,4 +27,4 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
 
     isMemberOf: (group) ->
       _.find @memberships(), (membership) ->
-        membership.groupId == group.id 
+        membership.groupId == group.id


### PR DESCRIPTION
@mixmix 

hotfix for #267 

suppose a user is reinvited by an admin, but that user ends up logging in normally (rather than clicking on the confirm-account link in the email sent by the admin). with the proposed changes in #267, if this were to happen, the user's `invited` label under their name on the funders page would not disappear. hence, this PR.

in this PR: 
when a user successfully logs in, if they have a `confirmation_token`, it is removed.
the presence of a `confirmation_token` on a user is how we tell whether a user is `invited` or not. so, by removing the `confirmation_token` on login-success, we remove the `invited` label for that user.

demonstrative gif: http://g.recordit.co/1Ry0bRiLwD.gif
partner API PR: https://github.com/cobudget/cobudget-api/pull/100