### PR TITLE
Bug/user can edit any bucket

### DIFF
--- a/app/components/edit-bucket-page/edit-bucket-page.coffee
+++ b/app/components/edit-bucket-page/edit-bucket-page.coffee
@@ -1,4 +1,4 @@
-module.exports = 
+module.exports =
   resolve:
     userValidated: ($auth) ->
       $auth.validateUser()
@@ -6,22 +6,22 @@ module.exports =
       global.cobudgetApp.membershipsLoaded
   url: '/buckets/:bucketId/edit'
   template: require('./edit-bucket-page.html')
-  controller: ($scope, Records, $stateParams, $location, Toast, UserCan, Error) ->
-    
+  controller: (Error, $location, Records, $scope, $stateParams, Toast, UserCan) ->
+
     bucketId = parseInt $stateParams.bucketId
 
     Records.buckets.findOrFetchById(bucketId)
       .then (bucket) ->
-        if UserCan.viewBucket(bucket)
+        if UserCan.editBucket(bucket)
           $scope.authorized = true
           Error.clear()
           $scope.bucket = bucket
         else
           $scope.authorized = false
-          Error.set('cannot view bucket')
+          Error.set('cannot edit bucket')
       .catch ->
         Error.set('bucket not found')
-        
+
     $scope.cancel = () ->
       $location.path("/buckets/#{bucketId}")
 

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -28,3 +28,7 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
     isMemberOf: (group) ->
       _.find @memberships(), (membership) ->
         membership.groupId == group.id
+
+    isAdminOf: (group) ->
+      _.find @memberships(), (membership) ->
+        membership.groupId == group.id && membership.isAdmin

--- a/app/services/user-can.coffee
+++ b/app/services/user-can.coffee
@@ -1,9 +1,8 @@
 null
 
 ### @ngInject ###
-global.cobudgetApp.factory 'UserCan', ($location, $q, Records, Toast) ->
+global.cobudgetApp.factory 'UserCan', (CurrentUser, $location, $q, Records, Toast) ->
   new class UserCan
-
     viewGroup: (group) ->
       validMemberships = Records.memberships.find({
         groupId: group.id,
@@ -13,6 +12,10 @@ global.cobudgetApp.factory 'UserCan', ($location, $q, Records, Toast) ->
 
     viewBucket: (bucket) ->
       @viewGroup(bucket.group())
+
+    editBucket: (bucket) ->
+      isBucketAuthor = bucket.userId == global.cobudgetApp.currentUserId
+      isBucketAuthor || CurrentUser().isAdminOf(bucket.group())
 
     viewAdminPanel: ->
       validMemberships = Records.memberships.find({


### PR DESCRIPTION
trello ticket: https://trello.com/c/Gh6ZgL4f/334-1-unauthorized-user-can-visit-edit-bucket-page-by-entering-in-bucket-bucketid-edit
partner API PR: https://github.com/cobudget/cobudget-api/pull/103
demonstrative gif: http://g.recordit.co/Lz7l0D6S6o.gif

---

in this PR: added `UserCan#editBucket(bucket)` method that verifies that a user is either a group admin or bucket author before allowing them to see the `edit-bucket-page`