### PR TITLE
Bug/admins can only administrate groups they are an admin of

### DIFF
--- a/app/components/admin-page/admin-page.coffee
+++ b/app/components/admin-page/admin-page.coffee
@@ -17,7 +17,7 @@ module.exports =
     if UserCan.viewAdminPanel()
       $scope.authorized = true
       Error.clear()
-      $scope.accessibleGroups = CurrentUser().groups()
+      $scope.accessibleGroups = CurrentUser().administeredGroups()
     else
       $scope.authorized = false
       Error.set("you can't view this page")

--- a/app/directives/group-page-toolbar/group-page-toolbar.coffee
+++ b/app/directives/group-page-toolbar/group-page-toolbar.coffee
@@ -38,7 +38,7 @@ global.cobudgetApp.directive 'groupPageToolbar', () ->
         {label: 'Profile Settings', onClick: $scope.openProfileSettings, icon: 'person', isDisplayed: true},
         {label: 'Email Settings', onClick: $scope.openEmailSettings, icon: 'mail', isDisplayed: $scope.currentUser.isConfirmed()},
         {label: 'Give Feedback', onClick: $scope.openFeedbackForm, icon: 'live_help', isDisplayed: true},
-        {label: 'Admin Panel', onClick: $scope.openAdminPanel, icon: 'local_pizza', isDisplayed: $scope.currentUser.isAdminOf($scope.group)},
+        {label: 'Admin Panel', onClick: $scope.openAdminPanel, icon: 'local_pizza', isDisplayed: $scope.currentUser.isAGroupAdmin()},
         {label: 'Log Out', onClick: $scope.signOut, icon: 'exit_to_app', isDisplayed: true}
       ]
 

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -26,6 +26,9 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
       _.filter @groups(), (group) =>
         @isAdminOf(group)
 
+    isAGroupAdmin: () ->
+      @administeredGroups().length > 0
+
     primaryGroup: ->
       @groups()[0]
 

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -17,10 +17,14 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
     relationships: ->
       @hasMany 'memberships', with: 'memberId'
 
-    groups: ->
+    groups: () ->
       groupIds = _.map @memberships(), (membership) ->
         membership.groupId
       @recordStore.groups.find(groupIds)
+
+    administeredGroups: () ->
+      _.filter @groups(), (group) =>
+        @isAdminOf(group)
 
     primaryGroup: ->
       @groups()[0]


### PR DESCRIPTION
two bug fixes here:

- when visiting the `admin-panel`, an admin can only see groups that they are an admin of. before, they were able to see all groups that they were a part of. 

- on the `group-page-toolbar`s menu, the `Admin panel` btn is shown, no matter what the current group is, as long as the current user is an admin of at least one group.
