### PR TITLE
disable funding btn on submit

### DIFF
--- a/app/directives/bucket-page-progress-card/bucket-page-progress-card.coffee
+++ b/app/directives/bucket-page-progress-card/bucket-page-progress-card.coffee
@@ -23,6 +23,7 @@ global.cobudgetApp.directive 'bucketPageProgressCard', () ->
           $scope.newContribution.amount = +maxAllowableContribution.toFixed(2)
 
       $scope.submitContribution = ->
+        $scope.contributionSubmitted = true
         $scope.newContribution.save().then ->
           # hack, to get records to properly update
           Records.memberships.fetchMyMemberships().then ->

--- a/app/directives/bucket-page-progress-card/bucket-page-progress-card.html
+++ b/app/directives/bucket-page-progress-card/bucket-page-progress-card.html
@@ -31,7 +31,7 @@
       </md-input-container>
 
       <md-button class="md-raised md-primary bucket-page__fund-btn" ng-click='openFundForm()' ng-hide="fundFormOpened">Fund</md-button>
-      <md-button class="md-raised md-primary bucket-page__fund-btn" ng-click='submitContribution()' ng-if="fundFormOpened">Submit</md-button>
+      <md-button class="md-raised md-primary bucket-page__fund-btn" ng-click='submitContribution()' ng-if="fundFormOpened" ng-disabled="contributionSubmitted">Submit</md-button>
     </form>
   </md-card-content>
 </md-card>


### PR DESCRIPTION
![lol](http://g.recordit.co/QxbdhruDTF.gif)

should have been done a long time ago -- when a user funds a bucket, the submit button should be disabled so they can't accidentally overfund it 

merging now because simple, small, + necessary