### PR TITLE
disable target field on edit-bucket-page unless bucket status is draft

### DIFF
--- a/app/components/edit-bucket-page/edit-bucket-page.html
+++ b/app/components/edit-bucket-page/edit-bucket-page.html
@@ -52,7 +52,7 @@
 
       <md-input-container>
         <label>Funding Target (required for funding)</label>
-        <input ng-required="bucket.status == 'live'" name="target" min="1" type="text" ng-model="bucket.target" only-digits>
+        <input ng-disabled="bucket.status != 'draft'" name="target" min="1" type="text" ng-model="bucket.target" only-digits>
         <div ng-messages="bucketForm.target.$error" multiple>
           <div ng-message="required">This is required.</div>
           <div ng-message="min">Bucket target must be greater than zero</div>


### PR DESCRIPTION
partner API PR: https://github.com/cobudget/cobudget-api/pull/122
trello card: https://trello.com/c/28oRoEXy/514-non-idea-bucket-targets-shouldn-t-be-editable