### PR TITLE
disable comment form unless populated

### DIFF
--- a/app/directives/bucket-page-activity-card/bucket-page-activity-card.html
+++ b/app/directives/bucket-page-activity-card/bucket-page-activity-card.html
@@ -31,17 +31,16 @@
   <md-card class="bucket-page__comment-form-card">
     <form name='commentForm' class="bucket-page__comment-form" ng-submit="createComment()">
       <md-input-container class="bucket-page__comment-input-container" md-no-float>
-        <textarea type="text" class="bucket-page__comment-input" placeholder="Add a comment, question, or offer of support" ng-model="newComment.body" />
+        <textarea type="text" class="bucket-page__comment-input" required placeholder="Add a comment, question, or offer of support" name="body" ng-model="newComment.body" />
       </md-input-container>
 
       <div class="bucket-page__submit-comment-container">
         <a class="bucket-page__comment-form-markdown-link" href="https://www.loomio.org/markdown" target="_blank">formatting help</a>
         <md-input-container class="bucket-page__submit-comment-btn-container">
-          <md-button class="md-primary bucket-page__submit-comment-btn">submit</md-button>
+          <md-button class="md-primary bucket-page__submit-comment-btn" ng-disabled="commentForm.$invalid">submit</md-button>
         </md-input-container>
       </div>
 
     </form>
   </md-card>
 </div>
-  


### PR DESCRIPTION
[partner API PR](https://github.com/cobudget/cobudget-api/pull/128)
[trello card](https://trello.com/c/W5vcrKg6/420-blanked-and-maybe-duplicate-comments)

in this PR, i've made it so that the comment form can't be submitted if empty