### PR TITLE
fix ng-csv module build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "moment": "^2.8.4",
     "morph": "^0.2.0",
     "napa": "^1.2.0",
+    "ng-csv": "^0.3.6",
     "ng-download-csv": "^1.0.2",
     "ng-focus-if": "^1.0.2",
     "ng-q-all-settled": "^1.0.0",


### PR DESCRIPTION
Fix `browserify error { [Error: Cannot find module 'ng-csv' from '.../cobudget-ui/app']` error on build