### PR TITLE
Lowercase user email parameter on Allocation/Member CSV import

### DIFF
--- a/app/components/review-bulk-allocation-page/review-bulk-allocation-page.coffee
+++ b/app/components/review-bulk-allocation-page/review-bulk-allocation-page.coffee
@@ -76,7 +76,7 @@ module.exports =
 
       _.each $scope.newMembers, (newMember) ->
         newMember.status = 'pending'
-        membershipParams = {group_id: groupId, email: newMember.email}
+        membershipParams = {group_id: groupId, email: newMember.email.toLowerCase()}
         Records.memberships.remote.create(membershipParams).then (data) ->
           newMembership = data.memberships[0]
           if newMember.allocation_amount > 0

--- a/app/components/review-bulk-invite-members-page/review-bulk-invite-members-page.coffee
+++ b/app/components/review-bulk-invite-members-page/review-bulk-invite-members-page.coffee
@@ -63,7 +63,7 @@ module.exports =
 
       _.each $scope.newMembers, (newMember) ->
         newMember.status = 'pending'
-        params = {group_id: groupId, email: newMember.email}
+        params = {group_id: groupId, email: newMember.email.toLowerCase()}
         Records.memberships.remote.create(params).then (data) ->
           newMembership = data.memberships[0]
           Records.memberships.invite(newMembership).then ->


### PR DESCRIPTION
This resolves 400 errors on CSV import by lowercasing the email POST parameter.