### PR TITLE
Setting the default hash-prefix back to the empty string.

### DIFF
--- a/app/routes.coffee
+++ b/app/routes.coffee
@@ -1,5 +1,11 @@
 ### @ngInject ###
 
+# Since Angular 1.6 the default hash-prefix used for $location has changed from the empty string
+# to the bank ('!'). Since we're sending out links with only the hash, this needs to be set 
+# to the empty string 
+global.cobudgetApp.config(['$locationProvider', ($locationProvider) -> 
+  $locationProvider.hashPrefix('')])
+
 global.cobudgetApp.config ($stateProvider, $urlRouterProvider) ->
   $urlRouterProvider.otherwise '/'
   $stateProvider


### PR DESCRIPTION
This was updated to bang in angular 1.6 - since we're sending out links (and possibly have hardcoded links other places as well), I've changed the behaviour back to pre 1.6.