### PR TITLE
WIP Feature/saving

### DIFF
--- a/app/directives/group-page-buckets/group-page-buckets.coffee
+++ b/app/directives/group-page-buckets/group-page-buckets.coffee
@@ -5,7 +5,7 @@ global.cobudgetApp.directive 'groupPageBuckets', () ->
     restrict: 'E'
     template: require('./group-page-buckets.html')
     replace: true
-    controller: ($scope, $location) ->
+    controller: ($scope, $location, Dialog) ->
 
      $scope.showBucket = (bucketId) ->
        $location.path("/buckets/#{bucketId}")
@@ -15,5 +15,17 @@ global.cobudgetApp.directive 'groupPageBuckets', () ->
 
       $scope.hideArchivedBuckets = ->
         $scope.archivedBucketsShown = false
+
+      $scope.confirmSaving = (membership) ->
+        params =
+          membership:
+            saved_funds_at: moment()
+        membership.remote.update(membership.id, params)
+
+      $scope.indicateSaving = (membership) ->
+        Dialog.confirm({
+          content: "Thanks! This will help group admins know that the funds have not been abandoned."
+        }).then ->
+          $scope.confirmSaving(membership)
 
       return

--- a/app/directives/group-page-buckets/group-page-buckets.html
+++ b/app/directives/group-page-buckets/group-page-buckets.html
@@ -44,6 +44,17 @@
           </div>
         </div>
       </md-list-item>
+
+      <md-divider class="group-page__buckets-divider"></md-divider>
+
+      <md-list-item ng-if="membership.balance > 1" md-no-ink ng-click="indicateSaving(membership)" class="group-page__buckets-list-item">
+        <div layout="column" flex class="group-page__bucket-container">
+          <div layout="row" layout-align="start center" class="group-page__bucket-indicate-saving">
+            <small>Nothing strike your fancy? Click to save funds for later.</small>
+          </div>
+        </div>
+      </md-list-item>
+
     </md-list>
   </md-card>
 

--- a/app/directives/group-page-buckets/group-page-buckets.scss
+++ b/app/directives/group-page-buckets/group-page-buckets.scss
@@ -195,6 +195,11 @@
   font-weight: 400;
 }
 
+.group-page__bucket-indicate-saving {
+  color: #767676;
+  font-style: italic;
+}
+
 @media (max-width: 380px) {
   .group-page__bucket-title {
     @include fontMedium;
@@ -208,3 +213,4 @@
     @include fontTiny;
   }
 }
+

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -10,14 +10,6 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
       Records.memberships.fetchByGroupId($scope.group.id).then ->
         $scope.fundersLoaded = true
 
-      $scope.indicateSaving = (membership) ->
-        console.log('membership')
-        console.log(membership)
-        params =
-          membership:
-            saved_at: moment()
-        membership.remote.update(membership.id, params)
-
       $scope.toggleMemberAdmin = (membership) ->
         membership.isAdmin = !membership.isAdmin
         params =
@@ -27,9 +19,9 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
 
       $scope.downloadCSV = ->
         timestamp = moment().format('YYYY-MM-DD-HH-mm-ss')
-        filename = "#{$scope.group.name}-member-data-#{timestamp}"
+        filename = "#{$scope.group.name}-member-report-#{timestamp}"
         params =
-          url: "#{config.apiPrefix}/memberships.csv?group_id=#{$scope.group.id}"
+          url: "#{config.apiPrefix}/memberships/report.csv?group_id=#{$scope.group.id}"
           filename: filename
         DownloadCSV(params)
 

--- a/app/directives/group-page-funders/group-page-funders.coffee
+++ b/app/directives/group-page-funders/group-page-funders.coffee
@@ -10,6 +10,14 @@ global.cobudgetApp.directive 'groupPageFunders', () ->
       Records.memberships.fetchByGroupId($scope.group.id).then ->
         $scope.fundersLoaded = true
 
+      $scope.indicateSaving = (membership) ->
+        console.log('membership')
+        console.log(membership)
+        params =
+          membership:
+            saved_at: moment()
+        membership.remote.update(membership.id, params)
+
       $scope.toggleMemberAdmin = (membership) ->
         membership.isAdmin = !membership.isAdmin
         params =

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -32,6 +32,15 @@
               <span class="group-page__funder-admin-label" ng-if="funderMembership.isAdmin">(admin)</span>
             </div>
 
+            <md-button layout="column" layout-align="center end" class="group-page__funder-saving-container" ng-if="funderMembership.id == membership.id">
+            <span class="group-page__funder-saving"
+                ng-class=""
+                ng-click="indicateSaving(membership)"
+            >
+                save?
+            </span>
+            </md-button>
+
             <div layout="column" layout-align="center end" class="group-page__funder-balance-container">
               <span class="group-page__funder-balance"
                 ng-class="{'group-page__funder-balance-btn' : membership.isAdmin, 'group-page__funder-balance-personal' : funderMembership.id == membership.id, 'group-page__funder-balance-other' : funderMembership.id != membership.id}"

--- a/app/directives/group-page-funders/group-page-funders.html
+++ b/app/directives/group-page-funders/group-page-funders.html
@@ -11,7 +11,7 @@
         <span flex></span>
 
         <div class="group-page__funders-admin-btn" layout="row" layout-align="center center" ng-click="downloadCSV()" ng-if="membership.isAdmin">
-          <div class="group-page__funders-admin-btn-label">Download as CSV</div>
+          <div class="group-page__funders-admin-btn-label">Download Membership Report</div>
         </div>
       </div>
 

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -6,7 +6,7 @@ global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
     @singular: 'membership'
     @plural: 'memberships'
     @indices: ['groupId', 'memberId']
-    @serializableAttributes: ['isAdmin', 'closedAdminHelpCardAt', 'closedMemberHelpCardAt', 'savedAt']
+    @serializableAttributes: ['isAdmin', 'closedAdminHelpCardAt', 'closedMemberHelpCardAt', 'savedFundsAt']
 
     relationships: ->
       @belongsTo 'member', from: 'users'

--- a/app/models/membership-model.coffee
+++ b/app/models/membership-model.coffee
@@ -6,7 +6,7 @@ global.cobudgetApp.factory 'MembershipModel', (BaseModel) ->
     @singular: 'membership'
     @plural: 'memberships'
     @indices: ['groupId', 'memberId']
-    @serializableAttributes: ['isAdmin', 'closedAdminHelpCardAt', 'closedMemberHelpCardAt']
+    @serializableAttributes: ['isAdmin', 'closedAdminHelpCardAt', 'closedMemberHelpCardAt', 'savedAt']
 
     relationships: ->
       @belongsTo 'member', from: 'users'


### PR DESCRIPTION
add ability to indicate intentional savings. currently implemented in two places to see which we like better: on main buckets tab at the bottom of the active buckets list, and on the funders tab by the currently logged in user's name. also adds a confirm dialog for the saving with some explanatory text.

I'd love feedback on the placement and naming of the 'saving' options. @chime-mu and i had discussed possibly putting the 'save' button on the member profile menu (top right corner) but i find this confusing because that menu is not otherwise group-specific. we also discussed keeping it somewhat hidden because we are not what UI will make the most sense in the long term, and letting admins inform their users about the functionality rather than it being self-discovering. i am on the fence about this... i think it keeps our options open which is good, but is more likely to result in a half-built feature which relies on manual intervention.  

here's the first option, on the 'funders' tab:
![cb_intentional_save_opt1](https://cloud.githubusercontent.com/assets/59882/26509148/cc13869e-4257-11e7-8fe4-880bb9e6f7df.png)

and here's the second, on the buckets tab at the bottom:
![cb_intentional_save_opt2](https://cloud.githubusercontent.com/assets/59882/26509232/315d6970-4258-11e7-9098-2495efe24d59.png)

when you click the above, a confirm dialog appears to explain:
![cb_intentional_save_opt2b](https://cloud.githubusercontent.com/assets/59882/26509248/420fab98-4258-11e7-810d-49d02ff4583f.png)

again, these are mutually exclusive and maybe neither is right yet!

the second change is that i noticed admins can "download CSV" of current users in two separate places, and it does the same thing. one is on the "manage funds" page, and the other is at the top of the funders list. my thought was to replace the latter with an option to download a CSV "report" which would differ in that it would report on user activity rather than simply provide the format to add funds. here's what the button looks like now:
![cb_intentional_save_admin_report](https://cloud.githubusercontent.com/assets/59882/26509340/9a60a84c-4258-11e7-9ed9-842d76142b9d.png)

which still only appears if you are an admin. 









