### PR TITLE
Limit sidebar group list to groups the super admin is a real member of

### DIFF
--- a/app/directives/group-page-sidenav/group-page-sidenav.coffee
+++ b/app/directives/group-page-sidenav/group-page-sidenav.coffee
@@ -11,7 +11,7 @@ global.cobudgetApp.directive 'groupPageSidenav', () ->
         $mdSidenav('left').open()
 
       $scope.accessibleGroups = ->
-        CurrentUser() && CurrentUser().groups()
+        CurrentUser() && CurrentUser().groupsToDisplay()
 
       $scope.redirectToGroupPage = (groupId) ->
         if $state.current.name == 'group' && $scope.group.id == parseInt(groupId)

--- a/app/models/user-model.coffee
+++ b/app/models/user-model.coffee
@@ -20,6 +20,14 @@ global.cobudgetApp.factory 'UserModel', (BaseModel) ->
       @hasMany 'memberships', with: 'memberId'
       @belongsTo 'subscriptionTracker'
 
+    groupsToDisplay: () ->
+      selectMemberships = _.filter @memberships(), (membership) ->
+        membership.id
+
+      groupIds = _.map selectMemberships, (membership) ->
+        membership.groupId
+      @recordStore.groups.find(groupIds)
+
     groups: () ->
       groupIds = _.map @memberships(), (membership) ->
         membership.groupId


### PR DESCRIPTION
We added the ability for superadmins to browse all groups by creating fake memberships. But we don't want to show them on the sidebar. The superadmin can browse to groups they want to view directly using the group id. 